### PR TITLE
Add option to use alpino-server for query parsing

### DIFF
--- a/api/src/router.php
+++ b/api/src/router.php
@@ -31,13 +31,14 @@ $router->map('POST', '/generate_xpath', function () {
 
 $router->map('POST', '/parse_sentence', function () {
     $sentence = file_get_contents('php://input');
-    $location = alpino($sentence, 'ng'.time());
-
-    header('Content-Type: application/xml');
-    $parsed = fopen($location, 'r') or die('Unable to open parsed file! '.$location);
-    echo fread($parsed, filesize($location));
-    fclose($parsed);
-    unlink($location);
+    try {
+        $xml =  alpino($sentence, 'ng'.time());
+        header('Content-Type: application/xml');
+        echo $xml;
+    } catch(Exception $e) {
+        http_response_code(500);
+        die($e->getMessage());
+    }
 });
 
 $router->map('POST', '/metadata_counts', function () {

--- a/config-example.php
+++ b/config-example.php
@@ -13,7 +13,14 @@ defined('HOME_PATH') or define('HOME_PATH', buildHomeURL());
 // Whether or not to use an API to retrieve uploaded corpora. If empty, the corpora will need to be defined in the code.
 defined('API_URL') or define('API_URL', '');
 
+// === ALPINO SERVER  MODE ===
+// Whether or not to use alpino-server instead of starting a local instance
+$alpinoServerMode = false;
+$alpinoServerAddress = '';
+$alpinoServerPort = 0;
+
 // === CHANGE PATH TO ALPINO DIRECTORY === //
+// Only when $alpinoServerMode = false
 $alpinoDirectory = ROOT_PATH.'/parsers/Alpino';
 
 // In the recursive Javascript call, how many sentences to flush each time

--- a/preparatory-scripts/alpino-parser.php
+++ b/preparatory-scripts/alpino-parser.php
@@ -5,9 +5,42 @@
  * for the GrETEL2.0 project
  */
 
+ /**
+  * @return string the sentence as parsed by alpino.
+  * @throws Exception when Alpino cannot be contacted or fails to return in a timely manner
+  */
+function alpino_server($sentence) {
+    global $alpinoServerAddress;
+    global $alpinoServerPort;
+
+    $fs = fsockopen($alpinoServerAddress, $alpinoServerPort, $errno, $errstr);
+    if (!$fs) {
+        throw new Exception("Error contacting alpino at $alpinoServerAddress");
+    }
+    fwrite($fs, $sentence."\n\n");
+
+    while(!feof($fs) && ($part = fread($fs, 8096))) {
+        $xml .= $part;
+    }
+    fclose($fs);
+
+    if (!$xml) {
+        throw new Exception("Error parsing sentence with Alpino.");
+    }
+    return $xml;
+}
+
+/**
+ * @return string the sentence as parsed by alpino.
+ * @throws Exception when Alpino cannot be started/contacted or fails to return in a timely manner
+ */
 function alpino($sentence, $id)
 {
     global $alpinoDirectory;
+    global $alpinoServerMode;
+    if ($alpinoServerMode) {
+        return alpino_server($sentence);
+    }
 
     $descriptorspec = array(
               0 => array("pipe", "r"),  // stdin is a pipe that the child will read from
@@ -22,30 +55,42 @@ function alpino($sentence, $id)
     $process = proc_open($alpino, $descriptorspec, $pipes, $cwd, $env);
 
     if (!is_resource($process)) {
-        die('Error when parsing input with Alpino');
-    }
-    if (is_resource($process)) {
-        // $pipes now looks like this:
-        // 0 => writeable handle connected to child stdin
-        // 1 => readable handle connected to child stdout
-        // Any error output will be appended to /tmp/error-output.txt
-
-        // write sentence to standard input of Alpino
-        fwrite($pipes[0], "$id|$sentence");
-        fclose($pipes[0]);
-
-        // read results and print on web page
-        while (($buffer = fgets($pipes[1], 4096)) !== false) {
-            //       echo $buffer."\n";
-        }
-        fclose($pipes[1]);
-
-        // It is important that you close any pipes before calling
-        // proc_close in order to avoid a deadlock
-        $return_value = proc_close($process);
-
-        //    echo "command returned $return_value\n";
+        // die('Error when parsing input with Alpino');
+        throw new Exception("Error starting Alpino.");
     }
 
-    return ROOT_PATH."/tmp/$id.xml"; //return parse location
+    // $pipes now looks like this:
+    // 0 => writeable handle connected to child stdin
+    // 1 => readable handle connected to child stdout
+    // Any error output will be appended to /tmp/error-output.txt
+
+    // write sentence to standard input of Alpino
+    fwrite($pipes[0], "$id|$sentence");
+    fclose($pipes[0]);
+
+    // read results and print on web page
+    while (($buffer = fgets($pipes[1], 4096)) !== false) {
+        //       echo $buffer."\n";
+    }
+    fclose($pipes[1]);
+
+    // It is important that you close any pipes before calling
+    // proc_close in order to avoid a deadlock
+    $return_value = proc_close($process);
+    if ($return_value != 0) {
+        throw new Exception("Error parsing sentence with Alpino");
+    }
+
+    //    echo "command returned $return_value\n";
+    $location = ROOT_PATH."/tmp/$id.xml";
+    $parsed = fopen($location, 'r'); if (!$parsed);
+    if ($parsed) {
+        throw new Exception("Unable to open Alpino output");
+    }
+
+    return false;
+    $xml = fread($parsed, filesize($location));
+    fclose($parsed);
+    unlink($location);
+    return $xml;
 }


### PR DESCRIPTION
Before merging this - please verify that a locally run alpino returns status 0 on successful parsing. The return code was captured but not used and I've added the check, but I just realised that I didn't verify what status alpino actually returns on success. 