### PR TITLE
Feature/analysis none

### DIFF
--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -7461,9 +7461,9 @@
       }
     },
     "lassy-xpath": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/lassy-xpath/-/lassy-xpath-0.3.10.tgz",
-      "integrity": "sha512-dunSxxdTeKCj9TBwN93U3fTWf80dP0NnOTXB0qeUkx9LYp0EzWWwSufwOFhO4NeareVTD++hvbyNvNpbQzeMgg==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/lassy-xpath/-/lassy-xpath-0.3.11.tgz",
+      "integrity": "sha512-RpCzDq+t4Kl+an6f7AiESftAxodnXNv017S3GDc9wbLaz3jTB9lwrdrCrc+rtqFzhQu2Egr4zs/fVXOyE4djNA==",
       "requires": {
         "brace": "^0.11.1",
         "codelyzer": "^4.5.0",
@@ -7503,9 +7503,9 @@
           }
         },
         "sprintf-js": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-          "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
         },
         "tslint": {
           "version": "5.11.0",

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -7,7 +7,7 @@
         "serve": "ng serve --proxy-config proxy.conf.json",
         "serve:poll": "ng serve --poll=2000 --host 0.0.0.0 --proxy-config proxy.conf.json",
         "build": "ng build --prod --base-href=/ng/ --output-path=../ng",
-        "test": "ng test --source-map=false",
+        "test": "ng test",
         "lint": "ng lint",
         "e2e": "ng e2e"
     },
@@ -41,7 +41,7 @@
         "hammerjs": "^2.0.8",
         "jquery": "^3.3.1",
         "jquery-ui": "^1.12.1",
-        "lassy-xpath": "^0.3.10",
+        "lassy-xpath": "^0.3.11",
         "lodash": "^4.17.10",
         "ngx-clipboard": "^10.0.0",
         "node-sass": "^4.9.2",

--- a/web-ui/src/app/components/analysis/analysis.component.ts
+++ b/web-ui/src/app/components/analysis/analysis.component.ts
@@ -276,24 +276,14 @@ export class AnalysisComponent implements OnInit, OnDestroy {
         return results;
     }
 
-    /**
-     * Gets filters for an extracted xpath query
-     * @param id The variable name representing part of the query and the attribute name
-     * @param value The attribute value
-     */
-    private getFilterForQuery(id, value): FilterByXPath {
+    private getFilterForQuery(id: string, value: string) {
         const [variable, attribute] = id.split('.');
-        const attrSelector = value === AnalysisService.placeholder
-            ? `@${attribute}="" OR NOT(@${attribute})`
-            : `@${attribute}="${value}"`;
-        return {
-            field: id,
-            label: `${variable}[${attrSelector}]`,
-            type: 'xpath',
-            xpath: /^\*/.test(this.variables[variable].path)
-                ? attrSelector
-                : `${this.variables[variable].path.replace('$node/', '')}[${attrSelector}]`
-        };
+        return this.resultsService.getFilterForQuery(
+            variable,
+            attribute,
+            value === AnalysisService.placeholder
+                ? null
+                : value, this.variables);
     }
 
     private getFilterValue(field: string, value: string): FilterValue {

--- a/web-ui/src/app/components/analysis/analysis.component.ts
+++ b/web-ui/src/app/components/analysis/analysis.component.ts
@@ -283,7 +283,9 @@ export class AnalysisComponent implements OnInit, OnDestroy {
      */
     private getFilterForQuery(id, value): FilterByXPath {
         const [variable, attribute] = id.split('.');
-        const attrSelector = `@${attribute}="${value}"`;
+        const attrSelector = value === AnalysisService.placeholder
+            ? `@${attribute}="" OR NOT(@${attribute})`
+            : `@${attribute}="${value}"`;
         return {
             field: id,
             label: `${variable}[${attrSelector}]`,

--- a/web-ui/src/app/components/step/results/results.component.ts
+++ b/web-ui/src/app/components/step/results/results.component.ts
@@ -244,9 +244,9 @@ export class ResultsComponent extends StepComponent implements OnChanges, OnDest
     }
 
     public addFiltersXPath() {
-        this.customXPath = (this.xpath || this.customXPath).trimRight() + '\n' +
-            this.resultsService.createMetadataFilterQuery(
-                Object.values(this.filterValues));
+        this.customXPath = this.resultsService.createFilteredQuery(
+            this.xpath || this.customXPath,
+            Object.values(this.filterValues));
         this.filterChange({});
 
         this.xpathChange.next(this.customXPath);

--- a/web-ui/src/app/services/analysis.service.ts
+++ b/web-ui/src/app/services/analysis.service.ts
@@ -7,7 +7,12 @@ import { Hit } from './results.service';
 
 @Injectable()
 export class AnalysisService {
-    private getRow(variables: { [name: string]: string[] }, metadataKeys: string[], result: Hit, placeholder: string): Row {
+    /**
+     * If a value is missing for a column, this value is used instead.
+     */
+    public static placeholder = '(none)';
+
+    private getRow(variables: { [name: string]: string[] }, metadataKeys: string[], result: Hit): Row {
         let metadataValues: { [name: string]: string } = {};
         for (let key of metadataKeys) {
             metadataValues[key] = result.metaValues[key];
@@ -18,7 +23,7 @@ export class AnalysisService {
             let node = result.variableValues[name];
             let values: { [attribute: string]: string } = {};
             for (let attribute of variables[name]) {
-                values[attribute] = node && node[attribute] ? node[attribute] : placeholder;
+                values[attribute] = node && node[attribute] || AnalysisService.placeholder;
             };
             nodeVariableValues[name] = values;
         }
@@ -54,14 +59,13 @@ export class AnalysisService {
      * @param searchResults The results to parse.
      * @param variables The variables and their properties to return, which should be present in the results.
      * @param metadataKeys The metadata keys to return, which should be present in the results.
-     * @param placeholder If a value is missing for a column, this value is used instead.
      * @returns The first row contains the column names, the preceding the associated values.
      */
-    public getFlatTable(searchResults: Hit[], variables: { [name: string]: string[] }, metadataKeys: string[], placeholder = '(none)'): string[][] {
+    public getFlatTable(searchResults: Hit[], variables: { [name: string]: string[] }, metadataKeys: string[]): string[][] {
         let rows: Row[] = [];
 
         for (let result of searchResults) {
-            let row = this.getRow(variables, metadataKeys, result, placeholder);
+            let row = this.getRow(variables, metadataKeys, result);
             rows.push(row);
         }
 
@@ -79,7 +83,7 @@ export class AnalysisService {
         for (let row of rows) {
             let line: string[] = [];
 
-            line.push(...metadataKeys.map(key => row.metadataValues[key] ? row.metadataValues[key] : placeholder));
+            line.push(...metadataKeys.map(key => row.metadataValues[key] || AnalysisService.placeholder));
             for (let name of Object.keys(variables)) {
                 line.push(...variables[name].map(attr => row.nodeVariableValues[name][attr]));
             }

--- a/web-ui/src/app/services/results.service.spec.ts
+++ b/web-ui/src/app/services/results.service.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { HttpClient } from '@angular/common/http';
 
+import { Location } from 'lassy-xpath/ng';
+
 import { ResultsService } from './results.service';
 import { HttpClientMock } from '../mocks/http-client.mock';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -22,5 +24,28 @@ describe('ResultsService', () => {
 
     it('should be created', inject([ResultsService], (service: ResultsService) => {
         expect(service).toBeTruthy();
+    }));
+
+    it('create filtered query', inject([ResultsService], (service: ResultsService) => {
+        const modified = service.createFilteredQuery(`//node[@cat="smain"
+        and node[@rel="su" and @pt="vnw"]
+        and node[@rel="hd" and @pt="ww"]
+        and node[@rel="predc" and @cat="np"
+            and node[@rel="det" and @pt="lid"]
+            and node[@rel="hd" and @pt="n"]]]
+`, [{
+                type: 'xpath',
+                location: new Location(3, 12, 16),
+                contextXpath: 'should be ignored',
+                attributeXpath: '[@test="test"]',
+                field: 'test.test',
+                label: 'test'
+            }]);
+        expect(modified).toEqual(`//node[@cat="smain"
+        and node[@rel="su" and @pt="vnw"]
+        and node[@test="test"][@rel="hd" and @pt="ww"]
+        and node[@rel="predc" and @cat="np"
+            and node[@rel="det" and @pt="lid"]
+            and node[@rel="hd" and @pt="n"]]]`);
     }));
 });


### PR DESCRIPTION
It is now possible to filter on cells having no attribute value (e.g. `@his` is often empty/non-existent). I also fixed a bug where filtering on sub-nodes was sometimes broken. Lastly, I've made the filtered xpath more compact by injecting only the filter attribute predicate after the relevant node.