### PR TITLE
Grind bugfix

### DIFF
--- a/api/src/router.php
+++ b/api/src/router.php
@@ -56,11 +56,13 @@ $router->map('GET', '/parse_sentence/[*:sentence]', function ($sentence) {
     }
 });
 
-$router->map('GET', '/tree/[*:treebank]/[*:sentid]', function ($treebank, $sentid) {
+$router->map('GET', '/tree/[*:treebank]/[*:component]/[*:sentid]', function ($treebank, $component, $sentid) {
     if (isset($_GET['db'])) {
-        $component = $_GET['db'];
+        $database = $_GET['db'];
+    } else {
+        $database = $component;
     }
-    showTree($sentid, $treebank, $component);
+    showTree($sentid, $treebank, $component, $database);
 });
 
 $router->map('POST', '/metadata_counts', function () {

--- a/api/src/show-tree.php
+++ b/api/src/show-tree.php
@@ -15,17 +15,17 @@
  */
 require_once ROOT_PATH.'/basex-search-scripts/basex-client.php';
 
-function showTree($sentid, $treebank, $component)
+function showTree($sentid, $treebank, $component, $database)
 {
     header('Content-type: text/xml');
     header('Access-Control-Allow-Origin: *');
     set_time_limit(0);
 
     try {
-        $xquery = 'db:open("'.$component.'")/treebank/alpino_ds[@id="'.$sentid.'"]';
-
         $serverInfo = getServerInfo($treebank, $component);
         $session = new Session($serverInfo['machine'], $serverInfo['port'], $serverInfo['username'], $serverInfo['password']);
+
+        $xquery = 'db:open("'.$database.'")/treebank/alpino_ds[@id="'.$sentid.'"]';
         $query = $session->query($xquery);
 
         $xml = $query->execute();

--- a/web-ui/src/app/components/page-components/footer/footer.component.html
+++ b/web-ui/src/app/components/page-components/footer/footer.component.html
@@ -64,14 +64,12 @@
                     </div>
                 </div>
                 <div class="column">
-                    <div class="level">
-                        <a class="university-logo level-left" href="https://uu.nl" target="_blank">
-                            <img src="assets/utrecht-university.svg" alt="Utrecht University logo" width="200" height="50" />
-                        </a>
-                        <a class="lab-logo level-right" href="https://dig.hum.uu.nl" target="_blank">
-                            <img src="assets/dhlab.svg" alt="Digital Humanities Lab logo" width="200" height="40" />
-                        </a>
-                    </div>
+                    <a class="university-logo" href="https://uu.nl" target="_blank">
+                        <img src="assets/utrecht-university.svg" alt="Utrecht University logo" width="200" height="50" />
+                    </a>
+                    <a class="lab-logo" href="https://dig.hum.uu.nl" target="_blank">
+                        <img src="assets/dhlab.svg" alt="Digital Humanities Lab logo" width="200" height="40" />
+                    </a>
                     <grt-adress></grt-adress>
                     <p class="version">
                         <em>Version: {{version}}</em>

--- a/web-ui/src/app/components/page-components/footer/footer.component.scss
+++ b/web-ui/src/app/components/page-components/footer/footer.component.scss
@@ -6,6 +6,7 @@
 .university-logo,
 .lab-logo {
     padding: 10px;
+    display: inline-block;
 }
 
 .lab-logo {

--- a/web-ui/src/app/components/step/results/results.component.ts
+++ b/web-ui/src/app/components/step/results/results.component.ts
@@ -256,10 +256,11 @@ export class ResultsComponent extends StepComponent<GlobalState> implements OnIn
         try {
             const treeXml = await this.resultsService.highlightSentenceTree(
                 result.provider,
-                result.fileId,
                 result.corpus,
+                result.component,
+                result.database,
+                result.fileId,
                 result.nodeIds,
-                result.component
             );
             this.treeXml = treeXml;
         } catch (e) {


### PR DESCRIPTION
Voor componenten gesplitst over meerdere databases: de databasenaam i.p.v. de componentnaam werd gezet als origin van een hit (frontend JS bug). Hierdoor ging het ophalen van de displayname mis (en nog wel maar dan werkte het al niet meer).

Zelfde verhaal met het ophalen van een volledige xml tree van een resultaat, ook hier moet het database zowel als de componentnaam expliciet meegegeven worden omdat uit een component id alleen helaas niet genoeg valt te halen om de zin altijd terug te vinden (zonder alle databases voor dat component te queryen).

Ik heb ook even de overlappende logo's in de footer (op smallere displays) rechtgestreken :) 
