### PR TITLE
Fixes weird tree xml-parsing bug

### DIFF
--- a/web-ui/src/app/components/tree-visualizer/tree-visualizer.js
+++ b/web-ui/src/app/components/tree-visualizer/tree-visualizer.js
@@ -193,7 +193,7 @@ var jQuery = require('jquery');
         }
 
         function parseXMLObj(xml) {
-            var xmlObject = $(xml);
+            var xmlObject = $($.parseXML(xml));
 
             removeError();
 


### PR DESCRIPTION
Changed `var xmlObject = $(xml);`

![Elongated tree](https://user-images.githubusercontent.com/24268578/154708211-b1ddb83a-2ad0-4d4d-9a4b-a501997766e6.png)

To `var xmlObject = $($.parseXML(xml));`

![Fixed tree](https://user-images.githubusercontent.com/24268578/154708148-4808df61-8d2e-42f6-99de-6bd84b4ed699.png)

![Magic!](https://www.memesmonkey.com/images/memesmonkey/77/771330e9f7a2a22e7b412187a657045c.jpeg)
