### PR TITLE
Feature/flush no results

### DIFF
--- a/api/src/results.php
+++ b/api/src/results.php
@@ -37,31 +37,15 @@ function getResults($xpath, $context, $corpus, $components, $databases, $start, 
     // Get sentences for the first component in the array of remaining components
     $results = getSentences($corpus, $components[0], $databases, $start, $session, $searchLimit, $xpath, $context, $variables);
 
-    if (!$results['success']) {
-        // no results, only contains false success state and the xquery (for debugging)
-        // Are there still components left? If so, remove the first component
-        // from the list and recursively call this function.
+    if (!$results['remainingDatabases']) {
+        // If done with current components (remainingDatabases finished):
+        // remove it from the list and get the databases for the next components
         array_shift($components);
-        if ($components) {
-            $databases = null;
-            $start = 0;
-            $results = getResults($xpath, $context, $corpus, $components, $databases, $start, $searchLimit, $variables, $session);
-        }
-        // NB: removing the recursive call to make sure that only one component
-        // at a time is searched will not work, because in that case only
-        // the false success state will be returned to the frontend and
-        // frontend will think that searching has finished.
-    } else {
-        if (!$results['remainingDatabases']) {
-            // If done with current components (remainingDatabases finished)
-            // Remove it from the list and get the databases for the next components
-            array_shift($components);
-            $results['remainingDatabases'] = isset($components[0])
-                ? getDatabases($corpus, $components[0], $xpath)
-                : array();
-        }
-        $results['remainingComponents'] = $components;
+        $results['remainingDatabases'] = isset($components[0])
+            ? getDatabases($corpus, $components[0], $xpath)
+            : array();
     }
+    $results['remainingComponents'] = $components;
 
     if ($newSession) {
         // Only close a new session, because this function may be called

--- a/api/src/results.php
+++ b/api/src/results.php
@@ -13,7 +13,7 @@ require_once ROOT_PATH.'/basex-search-scripts/treebank-search.php';
  * @param bool     $context     retrieve preceding and following sentences?
  * @param string   $corpus      treebank to search
  * @param string[] $components  the component we're searching
- * @param string[] $databases   list of databases that remain to be searched in this component
+ * @param string[] $databases   list of databases that remain to be searched in this component (null if all should be selected)
  * @param int      $start       pagination info, hits to skip in current database
  * @param int      $searchLimit max number of results to retrieve in this call
  * @param array    $variables
@@ -31,20 +31,26 @@ function getResults($xpath, $context, $corpus, $components, $databases, $start, 
     }
 
     if ($databases == null) {
+        // Find all databases belonging to this component (may be one)
         $databases = getDatabases($corpus, $components[0], $xpath);
     }
+    // Get sentences for the first component in the array of remaining components
     $results = getSentences($corpus, $components[0], $databases, $start, $session, $searchLimit, $xpath, $context, $variables);
 
     if (!$results['success']) {
         // no results, only contains false success state and the xquery (for debugging)
-        // are there still components left?
-
+        // Are there still components left? If so, remove the first component
+        // from the list and recursively call this function.
         array_shift($components);
         if ($components) {
             $databases = null;
             $start = 0;
             $results = getResults($xpath, $context, $corpus, $components, $databases, $start, $searchLimit, $variables, $session);
         }
+        // NB: removing the recursive call to make sure that only one component
+        // at a time is searched will not work, because in that case only
+        // the false success state will be returned to the frontend and
+        // frontend will think that searching has finished.
     } else {
         if (!$results['remainingDatabases']) {
             // If done with current components (remainingDatabases finished)
@@ -58,6 +64,9 @@ function getResults($xpath, $context, $corpus, $components, $databases, $start, 
     }
 
     if ($newSession) {
+        // Only close a new session, because this function may be called
+        // recursively and the function call that created the session
+        // is the last to come to this part of the function.
         $session->close();
     }
 

--- a/api/src/router.php
+++ b/api/src/router.php
@@ -84,7 +84,8 @@ $router->map('POST', '/treebank_counts', function () {
     $components = $data['components'];
     $xpath = $data['xpath'];
 
-    $counts = getTreebankCounts($corpus, $components, $xpath);
+    // $counts = getTreebankCounts($corpus, $components, $xpath);
+    $counts = (object)[];
     header('Content-Type: application/json');
     echo json_encode($counts);
 });
@@ -133,7 +134,10 @@ $router->map('POST', '/results', function () {
     $flushLimit = $data['isAnalysis'] ? $analysisFlushLimit : $flushLimit;
     $flushLimit = min($flushLimit, $searchLimit);
 
-    // We only search one component at a time.
+    // Get results for given components (and databases, if applicable).
+    // NB: getResults stops after the first component or if flushLimit was
+    // reached; however, if no results are found, it continues searching until
+    // the end.
     $results = getResults(
         $xpath,
         $context,

--- a/api/src/router.php
+++ b/api/src/router.php
@@ -84,8 +84,7 @@ $router->map('POST', '/treebank_counts', function () {
     $components = $data['components'];
     $xpath = $data['xpath'];
 
-    // $counts = getTreebankCounts($corpus, $components, $xpath);
-    $counts = (object)[];
+    $counts = getTreebankCounts($corpus, $components, $xpath);
     header('Content-Type: application/json');
     echo json_encode($counts);
 });

--- a/api/src/router.php
+++ b/api/src/router.php
@@ -158,6 +158,9 @@ $router->map('POST', '/results', function () {
             $results['remainingDatabases'] = array();
             $results['remainingComponents'] = array();
         }
+    } else {
+        // If no results are found, give back the search limit that we started with
+        $results['searchLimit'] = $searchLimit;
     }
 
     header('Content-Type: application/json');

--- a/basex-search-scripts/treebank-search.php
+++ b/basex-search-scripts/treebank-search.php
@@ -142,6 +142,8 @@ function getDatabases($corpus, $component, $xpath)
 }
 
 /**
+ * Retrieve sentences from (what remains of) one component until
+ *
  * @param string   $corpus      the corpus we're searching
  * @param string   $component   the component we're searching
  * @param string[] $databases   the databases that remain to be searched in this component
@@ -156,14 +158,14 @@ function getSentences($corpus, $component, $databases, $start, $session, $search
 
     $xquery = 'N/A';
     try {
-        while ($database = array_pop($databases)) {
+        while ($database = array_shift($databases)) {
             $xquery = createXquery($corpus, $component, $database, $start, $start + $searchLimit, $needRegularGrinded, $context, $xpath, $variables);
             $query = $session->query($xquery);
             $result = $query->execute();
             $query->close();
 
             if (!$result || $result == 'false') {
-                // go to the next database and start at its first hit
+                // go to the next database of this component and start at its first hit
                 $start = 0;
                 continue;
             }

--- a/web-ui/src/app/services/results.service.ts
+++ b/web-ui/src/app/services/results.service.ts
@@ -382,22 +382,14 @@ export class ResultsService {
     }
 
     private async mapResults(results: ApiSearchResult): Promise<SearchResults> {
-        return results.success ?
-            {
-                hits: await this.mapHits(results),
-                nextIteration: results.endPosIteration,
-                remainingComponents: results.remainingComponents,
-                remainingDatabases: results.remainingDatabases,
-                needRegularGrinded: results.needRegularGrinded,
-                searchLimit: results.searchLimit
-            } : {
-                hits: [],
-                nextIteration: 0,
-                remainingDatabases: [],
-                remainingComponents: [],
-                needRegularGrinded: false,
-                searchLimit: 0
-            };
+        return {
+            hits: await this.mapHits(results),
+            nextIteration: results.endPosIteration,
+            remainingComponents: results.remainingComponents,
+            remainingDatabases: results.remainingDatabases,
+            needRegularGrinded: results.needRegularGrinded,
+            searchLimit: results.searchLimit,
+        };
     }
 
     private mapHits(results: ApiSearchResult): Promise<Hit[]> {
@@ -538,7 +530,7 @@ export class ResultsService {
  * each hit.
  */
 type ApiSearchResult = {
-    success: true
+    success: boolean
     /** Plain text sentences containing the hit */
     sentences: { [id: string]: string },
     /** Origin of the sentence (used for Grinded corpora) */
@@ -557,7 +549,7 @@ type ApiSearchResult = {
     endPosIteration: number,
     /** Components left to search */
     remainingComponents: string[],
-    /** Databases left to search for this component (if this is empty, the search is done) */
+    /** Databases left to search for first component */
     remainingDatabases: string[],
     /** Component ID where each hit originated */
     sentenceDatabases: { [id: string]: string },
@@ -567,11 +559,6 @@ type ApiSearchResult = {
     needRegularGrinded: boolean,
     /** Search limit */
     searchLimit: number
-} | {
-    // no results
-    success: false,
-    // xquery
-    xquery: string
 };
 
 /** Processed search results created from the response */


### PR DESCRIPTION
Change the backend and the frontend so that only one database at a time is searched per API request.

Roughly, this involves the following changes:

* Make the backend not continue the search if no results are found after finishing a component or a database within a component
* If no results are found, do not only return "success = false", but also the other variables, so that the frontend knows how to continue
* Adapt the frontend to accept the new return (just a few changes were necessary)

The PR also introduces a few more comments in the backend to make more clear what is going on. The PR still needs some cleanup before merging.

In combination with the import script ( #271 ) this makes it possible to search the Lassy Groot corpora in GrETEL. The EUROPARL treebank, which is 2GB large, now takes less than a minute to search through on my local machine if no results are found.

What remains to be done:

* Perhaps: increase the number of databases that are searched at a time (but still keep it limited, to ten or so). Since the upload script makes one database per input file, there are hundreds of databases, so that a very large number of requests is made. On my local computer that works well, but perhaps it does not work well remotely. (An alternative is making the databases in BaseX larger, but BaseX seems to perform best with a lot of small databases.)
* Give feedback to the user by showing the number of components that has already been searched
* Preferably: integrate giving results and counting search hits so that the database searching is not performed twice. If this is not possible (e.g. no time), disactivate counting for large corpora.