### PR TITLE
Refactored matrix logic

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,1 @@
-alpino-query>=2.1.5
+alpino-query>=2.1.6

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,1 @@
-alpino-query>=2.1.4
+alpino-query>=2.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-alpino-query==2.1.4
+alpino-query==2.1.5
     # via -r requirements.in
 lxml==4.7.1
     # via alpino-query

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-alpino-query==2.1.5
+alpino-query==2.1.6
     # via -r requirements.in
 lxml==4.7.1
     # via alpino-query

--- a/web-ui/.browserslistrc
+++ b/web-ui/.browserslistrc
@@ -10,3 +10,6 @@ last 2 versions
 Firefox ESR
 not dead
 not IE 9-11 # For IE 9-11 support, remove 'not'.
+# work-around for https://www.shanebart.com/angular-invalid-version-error/
+not ios_saf 15.2-15.3
+not safari 15.2-15.3

--- a/web-ui/angular.json
+++ b/web-ui/angular.json
@@ -45,7 +45,7 @@
               "optimization": true,
               "outputHashing": "all",
               "namedChunks": false,
-              "aot": false,
+              "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": false,

--- a/web-ui/src/app/components/page-components/header/header.component.html
+++ b/web-ui/src/app/components/page-components/header/header.component.html
@@ -12,7 +12,8 @@
             <span aria-hidden="true"></span>
         </a>
     </div>
-    <grt-navigation class="navbar-menu" [ngClass]="{'is-active':menuExpanded}"></grt-navigation>
+    <grt-navigation class="navbar-menu" [ngClass]="{'is-active':menuExpanded}" (click)="menuExpanded=!menuExpanded">
+    </grt-navigation>
 </nav>
 <div class="notification is-radiusless" *ngIf="show" [ngClass]="messageType" [@slideDown]>
     <button class="delete" (click)="show=false"></button>

--- a/web-ui/src/app/components/page-components/header/login-status/login-status.component.html
+++ b/web-ui/src/app/components/page-components/header/login-status/login-status.component.html
@@ -44,7 +44,7 @@
                 <div class="field">
                     <div class="control">
                         <button class="button" type="submit"
-                            [ngClass]="{'is-loading': loading, 'is-primary': !loggingIn, 'is-danger':error}">
+                            [ngClass]="{'is-loading': loading, 'is-primary': !loading, 'is-danger':error}">
                             Login
                         </button>
                     </div>

--- a/web-ui/src/app/components/step/analysis/analysis.component.ts
+++ b/web-ui/src/app/components/step/analysis/analysis.component.ts
@@ -28,6 +28,7 @@ import { TreebankMetadata } from '../../../treebank';
 import { StepDirective } from '../step.directive';
 import { GlobalState, StepType, getSearchVariables } from '../../../pages/multi-step-page/steps';
 import { AddNodeEvent } from '../../node-properties/node-properties-editor.component';
+import { TreeVisualizerDisplay } from '../../tree-visualizer/tree-visualizer.component';
 
 @Component({
     animations,
@@ -61,7 +62,7 @@ export class AnalysisComponent extends StepDirective<GlobalState> implements OnI
 
     public variables: { [name: string]: PathVariable; };
     public treeXml: string;
-    public treeDisplay = 'inline';
+    public treeDisplay: TreeVisualizerDisplay = 'inline';
 
     public isLoading = true;
 

--- a/web-ui/src/app/components/step/matrix/matrix-option.component.html
+++ b/web-ui/src/app/components/step/matrix/matrix-option.component.html
@@ -1,4 +1,4 @@
-<div class="button is-outlined" [ngClass]="iconColor" [attr.disabled]="disabled ? 'disabled' : undefined" role="button"
+<div class="button is-outlined" [ngClass]="iconColor" role="button"
     tooltipPosition="bottom" pTooltip="{{iconDescription}}">
     <span class="icon">
         <fa-icon *ngIf="iconDefinition" [icon]="iconDefinition"></fa-icon>

--- a/web-ui/src/app/components/step/matrix/matrix-option.component.ts
+++ b/web-ui/src/app/components/step/matrix/matrix-option.component.ts
@@ -1,84 +1,9 @@
 import { Component, Input } from '@angular/core';
 import { IconDefinition, faEquals, faNotEqual, faCheck } from '@fortawesome/free-solid-svg-icons';
-import { DefaultTokenAttributes } from '../../../pages/multi-step-page/steps';
 
 import { animations } from '../../../animations';
-import { AttributeType, TokenAttributes } from '../../../services/_index';
+import { FilterValue, MatrixOption } from '../../../models/matrix';
 
-export type Option = {
-    type: 'bool' | 'default';
-    label: string;
-    description: string;
-    value: AttributeType;
-    dependent_on?: AttributeType;
-    advanced: boolean;
-    exclusive: boolean;
-}
-
-export const options: Option[] = [
-    {
-        label: 'Relation',
-        description: 'The exact word form (also known as token).',
-        value: 'rel',
-        advanced: false,
-        exclusive: false,
-        type: 'default'
-    },
-    {
-        label: 'Word',
-        description: 'The exact word form (also known as token).',
-        value: 'word',
-        advanced: false,
-        exclusive: false,
-        type: 'default'
-    },
-    {
-        label: 'Word (case-sensitive)',
-        description: 'The word form must match exactly, including the casing.',
-        dependent_on: 'word',
-        value: 'cs',
-        advanced: true,
-        exclusive: false,
-        type: 'bool'
-    },
-    {
-        label: 'Lemma',
-        description: `Word form that generalizes over inflected forms.
-        For example: gaan is the lemma of ga, gaat, gaan, ging, gingen, and gegaan.`,
-        value: 'lemma',
-        advanced: false,
-        exclusive: false,
-        type: 'default'
-    },
-    {
-        label: 'Word class',
-        description: `Short Dutch part-of-speech tag.
-        The different tags are:
-        n (noun), ww (verb), adj (adjective), lid (article), vnw (pronoun),
-        vg (conjunction), bw (adverb), tw (numeral), vz (preposition),
-        tsw (interjection), spec (special token), and let (punctuation).`,
-        value: 'pos',
-        advanced: false,
-        exclusive: false,
-        type: 'default'
-    },
-    {
-        label: 'Detailed word class',
-        description: 'Long part-of-speech tag. For example: N(soort,mv,basis), WW(pv,tgw,ev), VNW(pers,pron,nomin,vol,2v,ev).',
-        value: 'postag',
-        advanced: true,
-        exclusive: false,
-        type: 'default'
-    },
-    {
-        label: 'Optional',
-        description: `The word will be ignored in the search instruction.
-        It may be included in the results, but it is not required that it is present.`,
-        value: 'na',
-        advanced: false,
-        exclusive: true,
-        type: 'bool'
-    }];
 
 @Component({
     animations,
@@ -88,21 +13,21 @@ export const options: Option[] = [
 })
 export class MatrixOptionComponent {
     @Input()
-    attributes: TokenAttributes;
+    value: boolean | FilterValue;
 
     @Input()
-    option: Option;
+    option: MatrixOption;
 
     @Input()
-    disabled: boolean;
+    dependent: boolean;
 
     get iconDefinition(): IconDefinition {
-        if (!this.option || !this.attributes || this.disabled) {
+        if (!this.option || this.dependent) {
             return undefined;
         }
 
         if (this.option.type === 'default') {
-            switch (this.attributes[this.option.value]) {
+            switch (this.value) {
                 case 'include':
                     return faEquals;
 
@@ -114,15 +39,12 @@ export class MatrixOptionComponent {
             }
         }
 
-        return this.attributes[this.option.value] ?
-            faCheck : undefined;
+        return this.value ? faCheck : undefined;
     }
 
     get iconColor() {
-        if (!this.disabled && this.option && this.attributes) {
-            const key = this.option.value;
-            const value = this.attributes[key];
-            switch (value) {
+        if (!this.dependent && this.option) {
+            switch (this.value) {
                 case 'include':
                 case true:
                     return 'is-primary';
@@ -137,11 +59,11 @@ export class MatrixOptionComponent {
     }
 
     get iconText() {
-        if (!this.option || !this.attributes) {
+        if (!this.option) {
             return '';
         }
 
-        const value = this.disabled ? undefined : this.attributes[this.option.value];
+        const value = this.dependent ? undefined : this.value;
         switch (value) {
             case undefined:
                 return 'any';
@@ -158,14 +80,17 @@ export class MatrixOptionComponent {
     }
 
     get iconDescription() {
-        if (this.option && this.attributes) {
+        if (this.dependent) {
+            return undefined;
+        }
+
+        if (this.option) {
             if (this.option.type == 'bool') {
                 // yes/no doesn't require explanation
                 return undefined;
             }
 
-            const key = this.option.value;
-            const value = this.disabled ? undefined : this.attributes[key];
+            const value = this.dependent ? undefined : this.value;
             const label = this.option.label.toLowerCase();
             switch (value) {
                 case 'include':
@@ -178,6 +103,6 @@ export class MatrixOptionComponent {
             }
         }
 
-        return this.disabled ? 'disabled' : '???';
+        return undefined;
     }
 }

--- a/web-ui/src/app/components/step/matrix/matrix.component.html
+++ b/web-ui/src/app/components/step/matrix/matrix.component.html
@@ -19,8 +19,8 @@
                         </span>
                     </th>
                     <td [@fade] *ngFor="let token of indexedTokens" (click)="setTokenPart(token, option)">
-                        <grt-matrix-option [attributes]="tokenValues[token.index]"
-                            [disabled]="tokenPartDisabled(token, option)" [option]="option"></grt-matrix-option>
+                        <grt-matrix-option [value]="attributes[token.index][option.key]"
+                            [dependent]="tokenDependents[token.index][option.key]" [option]="option"></grt-matrix-option>
                     </td>
                 </tr>
             </ng-container>

--- a/web-ui/src/app/components/step/matrix/matrix.component.html
+++ b/web-ui/src/app/components/step/matrix/matrix.component.html
@@ -4,13 +4,13 @@
         <thead>
             <tr>
                 <th>Sentence</th>
-                <td *ngFor="let token of indexedTokens">{{token.value}}</td>
+                <td *ngFor="let token of indexedTokens" class="is-clickable" (click)="setTokenPart(token, 'na')">{{token.value}}</td>
             </tr>
         </thead>
         <tbody>
             <ng-container *ngFor="let option of options">
                 <tr *ngIf="!option.advanced || showAdvanced">
-                    <th [@fade]>
+                    <th [@fade] class="is-clickable" (click)="setTokenRow(option.key)">
                         <span tooltipPosition="right" pTooltip="{{option.description}}">
                             {{option.label}}
                             <label>
@@ -18,7 +18,7 @@
                             </label>
                         </span>
                     </th>
-                    <td [@fade] *ngFor="let token of indexedTokens" (click)="setTokenPart(token, option)">
+                    <td [@fade] *ngFor="let token of indexedTokens" (click)="setTokenPart(token, option.key)">
                         <grt-matrix-option [value]="attributes[token.index][option.key]"
                             [dependent]="tokenDependents[token.index][option.key]" [option]="option"></grt-matrix-option>
                     </td>

--- a/web-ui/src/app/components/step/matrix/matrix.component.scss
+++ b/web-ui/src/app/components/step/matrix/matrix.component.scss
@@ -1,3 +1,5 @@
+@import "../../../../colors";
+
 .xpath {
     // they can be nested quite deeply
     overflow: auto;
@@ -19,4 +21,10 @@
 // allow clicking the disabled radio buttons for notification
 input[disabled] {
     pointer-events: none
+}
+
+th.is-clickable:hover,
+td.is-clickable:hover {
+    background-color: $secondary;
+    color: $secondary-invert;
 }

--- a/web-ui/src/app/components/step/matrix/matrix.component.ts
+++ b/web-ui/src/app/components/step/matrix/matrix.component.ts
@@ -9,7 +9,7 @@ import { StepDirective } from '../step.directive';
 import { StepType, GlobalStateExampleBased } from '../../../pages/multi-step-page/steps';
 import { NotificationService } from '../../../services/notification.service';
 import { animations } from '../../../animations';
-import { matrixOptions, Matrix, MatrixOption, TokenAttributes, TokenDependents } from '../../../models/matrix';
+import { matrixOptions, Matrix, TokenAttributes, TokenDependents, MatrixOptionKey } from '../../../models/matrix';
 
 interface IndexedToken {
     /**
@@ -108,13 +108,25 @@ export class MatrixComponent extends StepDirective<GlobalStateExampleBased> impl
         ];
     }
 
-    public setTokenPart(token: IndexedToken, option: MatrixOption) {
+    public setTokenRow<T extends MatrixOptionKey>(key: T) {
         if (this.isCustomXPath) {
             this.warningId = this.notificationService.add('It is not possible to use the matrix when using custom xpath.');
             return;
         }
 
-        this.matrix.rotate(token.index, option.key);
+        this.matrix.rotateRow(key);
+        this.updateMatrix();
+
+        this.emitChange();
+    }
+
+    public setTokenPart(token: IndexedToken, key: MatrixOptionKey) {
+        if (this.isCustomXPath) {
+            this.warningId = this.notificationService.add('It is not possible to use the matrix when using custom xpath.');
+            return;
+        }
+
+        this.matrix.rotate(token.index, key);
         this.updateMatrix();
 
         this.emitChange();
@@ -125,6 +137,10 @@ export class MatrixComponent extends StepDirective<GlobalStateExampleBased> impl
         let { advanced, dependents } = this.matrix.info();
         this.alwaysAdvanced = advanced;
         this.tokenDependents = dependents;
+        if (advanced) {
+            // this might happen when the page is reloaded
+            this.showAdvanced = true;
+        }
         // hello change detection
         this.indexedTokens = [...this.indexedTokens];
     }

--- a/web-ui/src/app/components/step/matrix/matrix.component.ts
+++ b/web-ui/src/app/components/step/matrix/matrix.component.ts
@@ -10,6 +10,7 @@ import { StepType, GlobalStateExampleBased } from '../../../pages/multi-step-pag
 import { NotificationService } from '../../../services/notification.service';
 import { animations } from '../../../animations';
 import { matrixOptions, Matrix, TokenAttributes, TokenDependents, MatrixOptionKey } from '../../../models/matrix';
+import { TreeVisualizerDisplay } from '../../tree-visualizer/tree-visualizer.component';
 
 interface IndexedToken {
     /**
@@ -65,7 +66,7 @@ export class MatrixComponent extends StepDirective<GlobalStateExampleBased> impl
     public changeValue = new EventEmitter<MatrixSettings>();
 
     public filename: string;
-    public subTreeDisplay = 'inline';
+    public subTreeDisplay: TreeVisualizerDisplay = 'inline';
     public warning: boolean;
 
     public indexedTokens: IndexedToken[];

--- a/web-ui/src/app/components/step/matrix/matrix.component.ts
+++ b/web-ui/src/app/components/step/matrix/matrix.component.ts
@@ -4,28 +4,20 @@ import { ConfirmationService } from 'primeng/api';
 
 import { ValueEvent } from 'lassy-xpath';
 
-import { StateService, TokenAttributes } from '../../../services/_index';
+import { StateService } from '../../../services/_index';
 import { StepDirective } from '../step.directive';
-import { StepType, GlobalStateExampleBased, DefaultTokenAttributes } from '../../../pages/multi-step-page/steps';
+import { StepType, GlobalStateExampleBased } from '../../../pages/multi-step-page/steps';
 import { NotificationService } from '../../../services/notification.service';
 import { animations } from '../../../animations';
-import { Option, options } from './matrix-option.component';
-
-const optionsLookup = Object.assign(
-    {},
-    ...options.map(option => ({ [option.value]: option }))) as { [key: string]: Option };
+import { matrixOptions, Matrix, MatrixOption, TokenAttributes, TokenDependents } from '../../../models/matrix';
 
 interface IndexedToken {
     /**
      * string value of this token
      */
     value: string,
-    index: number,
-    /**
-     * the key of the exclusive option set for this token (or undefined)
-     */
-    exclusive: keyof TokenAttributes
-};
+    index: number
+}
 
 @Component({
     animations,
@@ -36,67 +28,12 @@ interface IndexedToken {
 export class MatrixComponent extends StepDirective<GlobalStateExampleBased> implements OnInit, OnDestroy {
     private warningId: number;
     private subscriptions: Subscription[];
+    private matrix: Matrix;
+
     public stepType = StepType.Matrix;
 
-    private set attributes(tokens: TokenAttributes[]) {
-        let alwaysAdvanced = false;
-        let updatedTokens = false;
-
-        for (let i in tokens) {
-            let token = tokens[i];
-            if (token != null) {
-                for (let [key, value] of Object.entries(token)) {
-                    var option = optionsLookup[key];
-                    if (option.advanced) {
-                        if (value !== DefaultTokenAttributes[key]) {
-                            this.showAdvanced = true;
-                            alwaysAdvanced = true;
-                        }
-                    }
-
-                    if (this.indexedTokens) {
-                        if (option.exclusive) {
-                            if (value === true || value === 'include') {
-                                // checked exclusive option
-                                if (this.indexedTokens[i].exclusive !== option.value) {
-                                    updatedTokens = true;
-                                }
-                                this.indexedTokens[i].exclusive = option.value;
-                            } else {
-                                // unchecked exclusive option
-                                if (this.indexedTokens[i].exclusive == option.value) {
-                                    updatedTokens = true;
-                                }
-                                this.indexedTokens[i].exclusive = undefined;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        if (updatedTokens) {
-            // hello change detection
-            this.indexedTokens = [...this.indexedTokens];
-        }
-
-        this.alwaysAdvanced = alwaysAdvanced;
-
-        if (this.tokenValues &&
-            tokens.length === this.tokenValues.length) {
-            // only update the values, but prevent the whole array
-            // from being re-rendered
-            for (let i = 0; i < tokens.length; i++) {
-                Object.assign(this.tokenValues[i], tokens[i]);
-            }
-        } else {
-            this.tokenValues = tokens;
-        }
-    }
-
-    private get attributes() {
-        return this.tokenValues;
-    }
+    public attributes: TokenAttributes[];
+    public tokenDependents: TokenDependents[];
 
     public set tokens(values: string[]) {
         if (this.indexedTokens &&
@@ -107,7 +44,7 @@ export class MatrixComponent extends StepDirective<GlobalStateExampleBased> impl
                 this.indexedTokens[i].value = values[i];
             }
         } else {
-            this.indexedTokens = values.map((value, index) => ({ value, index, exclusive: undefined }));
+            this.indexedTokens = values.map((value, index) => ({ value, index }));
         }
         this.filename = values.filter(t => t.match(/[^'"-:!?,\.]/)).join('-').toLowerCase() + '.xml';
     }
@@ -138,9 +75,7 @@ export class MatrixComponent extends StepDirective<GlobalStateExampleBased> impl
      */
     public alwaysAdvanced: boolean;
 
-    public tokenValues: TokenAttributes[];
-
-    public options = options;
+    public options = matrixOptions;
     public explanation: string = undefined;
 
     private originalXPath: string;
@@ -151,7 +86,6 @@ export class MatrixComponent extends StepDirective<GlobalStateExampleBased> impl
         super(stateService);
         this.subscriptions = [
             this.state$.subscribe(state => {
-                this.attributes = state.attributes;
                 this.ignoreTopNode = state.ignoreTopNode;
                 this.isCustomXPath = state.isCustomXPath;
                 this.respectOrder = state.respectOrder;
@@ -160,40 +94,39 @@ export class MatrixComponent extends StepDirective<GlobalStateExampleBased> impl
                 this.tokens = state.tokens;
                 this.xpath = state.xpath;
                 this.loading = state.loading;
+
+                let first = false;
+                if (this.matrix === undefined) {
+                    this.matrix = Matrix.default(state.tokens.length);
+                    // make sure a new matrix is initialized
+                    first = true;
+                }
+                if (this.matrix.setMultiple(state.attributes) || first) {
+                    this.updateMatrix();
+                }
             })
         ];
     }
 
-    public setTokenPart(token: IndexedToken, part: Option) {
+    public setTokenPart(token: IndexedToken, option: MatrixOption) {
         if (this.isCustomXPath) {
             this.warningId = this.notificationService.add('It is not possible to use the matrix when using custom xpath.');
             return;
         }
 
-        if (this.tokenPartDisabled(token, part)) {
-            return;
-        }
+        this.matrix.rotate(token.index, option.key);
+        this.updateMatrix();
 
-        var updated = this.rotateValue(token.index, part);
-
-        this.emitChange({
-            attributes: updated
-        });
+        this.emitChange();
     }
 
-    public tokenPartDisabled(token: IndexedToken, part: Option) {
-        if (token.exclusive !== undefined && token.exclusive !== part.value) {
-            return true;
-        }
-
-        if (part.dependent_on) {
-            const dependent = this.attributes[token.index][part.dependent_on];
-            if (dependent === undefined || dependent === false) {
-                return true;
-            }
-        }
-
-        return false;
+    private updateMatrix() {
+        this.attributes = this.matrix.attributes;
+        let { advanced, dependents } = this.matrix.info();
+        this.alwaysAdvanced = advanced;
+        this.tokenDependents = dependents;
+        // hello change detection
+        this.indexedTokens = [...this.indexedTokens];
     }
 
     private emitChange(settings: Partial<MatrixSettings> = {}) {
@@ -201,7 +134,7 @@ export class MatrixComponent extends StepDirective<GlobalStateExampleBased> impl
             this.valid = true;
         }
         this.changeValue.next(Object.assign({
-            attributes: this.tokenValues,
+            attributes: [...this.matrix.attributes],
             retrieveContext: this.retrieveContext,
             customXPath: settings.customXPath || null,
             respectOrder: this.respectOrder,
@@ -259,34 +192,6 @@ export class MatrixComponent extends StepDirective<GlobalStateExampleBased> impl
         this.notificationService.cancel(this.warningId);
         this.subscriptions.forEach(s => s.unsubscribe());
         super.ngOnDestroy();
-    }
-
-    private rotateValue(tokenIndex: number, option: Option): TokenAttributes[] {
-        var value = (this.tokenValues[tokenIndex][option.value] ??
-            optionsLookup[option.value]);
-        var options: any[];
-
-        switch (option.type) {
-            case 'default':
-                options = ['include', 'exclude', undefined];
-                break;
-
-            case 'bool':
-                options = [true, false];
-                break;
-        }
-
-        var index = options.indexOf(value) + 1;
-        var update = options[index % options.length];
-
-        return [
-            ...this.tokenValues.slice(0, tokenIndex),
-            {
-                ...this.tokenValues[tokenIndex],
-                [option.value]: update
-            },
-            ...this.tokenValues.slice(tokenIndex + 1)
-        ];
     }
 }
 

--- a/web-ui/src/app/components/step/parse/parse.component.html
+++ b/web-ui/src/app/components/step/parse/parse.component.html
@@ -18,7 +18,7 @@
 <p *ngIf="loading">Loading ...</p>
 <ng-container *ngIf="xml">
     <grt-tree-visualizer [xml]="xml" [display]="display" [fullScreenButton]="false"
-        (onDisplayChange)="display = $event"></grt-tree-visualizer>
+        (displayChange)="display = $event"></grt-tree-visualizer>
 </ng-container>
 <br />
 <div class="columns">

--- a/web-ui/src/app/components/step/parse/parse.component.ts
+++ b/web-ui/src/app/components/step/parse/parse.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, EventEmitter, Output, OnInit, OnDestroy } from '@angu
 import { StepDirective } from '../step.directive';
 import { StateService } from '../../../services/_index';
 import { GlobalStateExampleBased, StepType } from '../../../pages/multi-step-page/steps';
+import { TreeVisualizerDisplay } from '../../tree-visualizer/tree-visualizer.component';
 
 @Component({
     selector: 'grt-parse',
@@ -14,7 +15,7 @@ export class ParseComponent extends StepDirective<GlobalStateExampleBased> imple
     @Input() public xml: string;
     @Output() public changeXml = new EventEmitter<string>();
 
-    public display = 'inline';
+    public display: TreeVisualizerDisplay = 'inline';
     public stepType = StepType.Parse;
     public warning?: string;
 

--- a/web-ui/src/app/components/step/results/download-results.component.html
+++ b/web-ui/src/app/components/step/results/download-results.component.html
@@ -5,7 +5,7 @@
     </span>
 </a>
 <p-overlayPanel appendTo="body" [dismissable]="false" [showCloseIcon]="true">
-    <form (submit)="downloadResults()">
+    <form (submit)="downloadResults.next(includeNodeProperties)">
         <div class="field">
             <label class="checkbox">
                 <input type="checkbox" name="includeNodeProperties" [(ngModel)]="includeNodeProperties">

--- a/web-ui/src/app/components/step/results/download-results.component.ts
+++ b/web-ui/src/app/components/step/results/download-results.component.ts
@@ -1,7 +1,6 @@
-import { Component, ViewChild, OnInit, OnDestroy, Input } from '@angular/core';
+import { Component, ViewChild, OnInit, OnDestroy, Input, Output, EventEmitter } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { OverlayPanel } from 'primeng/overlaypanel';
-import { ResultsComponent } from './results.component';
 
 @Component({
     selector: 'grt-download-results',
@@ -17,14 +16,13 @@ export class DownloadResultsComponent implements OnInit, OnDestroy {
     @Input()
     loading = false;
 
+    @Output()
+    downloadResults = new EventEmitter<boolean>();
+
     visible = false;
     includeNodeProperties = false;
 
-    constructor(private resultsComponent: ResultsComponent) { }
-
-    downloadResults() {
-        this.resultsComponent.downloadResults(this.includeNodeProperties);
-    }
+    constructor() { }
 
     toggle($event: any) {
         this.overlayPanel.toggle($event);

--- a/web-ui/src/app/components/step/results/filters-by-xpath.component.html
+++ b/web-ui/src/app/components/step/results/filters-by-xpath.component.html
@@ -1,5 +1,5 @@
 <div class="field is-grouped is-grouped-multiline">
-    <div class="control" *ngFor="let filter of filters" [grtBalloon]="filter.xpath">
+    <div class="control" *ngFor="let filter of filters" [grtBalloon]="filter.attributeXpath">
         <div class="tags has-addons">
             <span class="tag is-medium">
                 <grt-xpath-viewer [value]="filter.label" [paddingless]="true"></grt-xpath-viewer>

--- a/web-ui/src/app/components/step/results/results.component.html
+++ b/web-ui/src/app/components/step/results/results.component.html
@@ -131,7 +131,7 @@
             <div class="level-item">
                 <div class="field has-addons">
                     <p class="control">
-                        <grt-download-results [loading]="loadingDownload"></grt-download-results>
+                        <grt-download-results [loading]="loadingDownload" (downloadResults)="downloadResults($event)"></grt-download-results>
                     </p>
                     <p class="control" *ngIf="!loading">
                         <a class="button" role="button" (click)="downloadFilelist()" grtBalloonLength="large"
@@ -256,4 +256,4 @@
     </div>
 </div>
 <grt-tree-visualizer *ngIf="loadingTree || treeXml" display="fullscreen" [sentence]="treeSentence" [xml]="treeXml"
-    [filename]="treeFilename" [url]="treeXmlUrl" [loading]="loadingTree"></grt-tree-visualizer>
+    [filename]="treeFilename" [loading]="loadingTree"></grt-tree-visualizer>

--- a/web-ui/src/app/components/step/results/results.component.ts
+++ b/web-ui/src/app/components/step/results/results.component.ts
@@ -32,11 +32,11 @@ import {
     ParseService,
     NotificationService
 } from '../../../services/_index';
-import { Filter } from '../../../modules/filters/filters.component';
 import { TreebankMetadata, TreebankSelection } from '../../../treebank';
 import { StepDirective } from '../step.directive';
 import { NotificationKind } from './notification-kind';
 import { GlobalState, StepType, getSearchVariables } from '../../../pages/multi-step-page/steps';
+import { Filter } from '../../../models/filter';
 
 const DebounceTime = 200;
 
@@ -501,7 +501,7 @@ export class ResultsComponent extends StepDirective<GlobalState> implements OnIn
                                 item.facet = 'dropdown';
                             }
 
-                            return {
+                            return <Filter>{
                                 field: item.field,
                                 dataType: item.type,
                                 filterType: item.facet,

--- a/web-ui/src/app/components/step/select-treebanks/sub-treebanks.component.html
+++ b/web-ui/src/app/components/step/select-treebanks/sub-treebanks.component.html
@@ -16,7 +16,7 @@
                 <th *ngIf="showDescription">
                     Description
                 </th>
-                <ng-container *ngFor="let variant of (variants || []).concat('')">
+                <ng-container *ngFor="let variant of (variants || [])">
                     <th class="has-text-right">
                         Sentences
                     </th>
@@ -24,6 +24,12 @@
                         Words
                     </th>
                 </ng-container>
+                <th class="has-text-right">
+                    Sentences
+                </th>
+                <th class="has-text-right" *ngIf="showWordCount">
+                    Words
+                </th>
             </tr>
 
             <tr *ngIf="variants">
@@ -41,8 +47,11 @@
                     &nbsp;
                 </th>
                 <!-- Variant sentence/wordcount col headers -->
-                <th *ngFor="let variant of variants.concat('Total')" colspan="2" class="has-text-centered">
+                <th *ngFor="let variant of variants" colspan="2" class="has-text-centered">
                     {{variant.name}}
+                </th>
+                <th colspan="2" class="has-text-centered">
+                    Total
                 </th>
             </tr>
         </thead>

--- a/web-ui/src/app/components/step/step.directive.ts
+++ b/web-ui/src/app/components/step/step.directive.ts
@@ -18,7 +18,7 @@ export abstract class StepDirective<T extends GlobalState> implements OnInit, On
         this.state$ = this.stateService.state$;
     }
 
-    @Output() changeValid = new EventEmitter<Boolean>();
+    @Output() changeValid = new EventEmitter<boolean>();
 
     /**
      * Gives an warning that helps the user to understand why the current input is not valid

--- a/web-ui/src/app/components/step/xpath-input/xpath-input.component.html
+++ b/web-ui/src/app/components/step/xpath-input/xpath-input.component.html
@@ -32,5 +32,5 @@
             </div>
         </div>
     </h2>
-    <grt-tree-visualizer [xml]="treeXml" [display]="treeDisplay" [fullScreenButton]="false" (onDisplayChange)="treeDisplay = $event"></grt-tree-visualizer>
+    <grt-tree-visualizer [xml]="treeXml" [display]="treeDisplay" [fullScreenButton]="false" (displayChange)="treeDisplay = $event"></grt-tree-visualizer>
 </ng-container>

--- a/web-ui/src/app/components/step/xpath-input/xpath-input.component.ts
+++ b/web-ui/src/app/components/step/xpath-input/xpath-input.component.ts
@@ -7,6 +7,7 @@ import { StepDirective } from '../step.directive';
 import { MacroService, ValueEvent, ReconstructorService, ExtractinatorService, PathVariable } from 'lassy-xpath';
 import { StateService } from '../../../services/_index';
 import { GlobalState, StepType } from '../../../pages/multi-step-page/steps';
+import { TreeVisualizerDisplay } from '../../tree-visualizer/tree-visualizer.component';
 
 @Component({
     selector: 'grt-xpath-input',
@@ -16,7 +17,7 @@ import { GlobalState, StepType } from '../../../pages/multi-step-page/steps';
 export class XpathInputComponent extends StepDirective<GlobalState> implements OnChanges, OnInit, OnDestroy {
     public stepType = StepType.XpathInput;
     public treeXml: string;
-    public treeDisplay = 'inline';
+    public treeDisplay: TreeVisualizerDisplay = 'inline';
     public warning = false;
 
     private valueSubject = new Subject<string>();

--- a/web-ui/src/app/components/tree-visualizer/external-tree-visualizer.component.html
+++ b/web-ui/src/app/components/tree-visualizer/external-tree-visualizer.component.html
@@ -1,2 +1,2 @@
-<grt-tree-visualizer *ngIf="xml" [display]="fullscreen" [sentence]="sentence || 'Unknown sentence'" [xml]="xml" (displayChange)="treeDisplay = $event"></grt-tree-visualizer>
+<grt-tree-visualizer *ngIf="xml" [display]="treeDisplay" [sentence]="sentence || 'Unknown sentence'" [xml]="xml" (displayChange)="treeDisplay = $event"></grt-tree-visualizer>
 <div *ngIf="!xml">No or invalid XML.</div>

--- a/web-ui/src/app/components/tree-visualizer/external-tree-visualizer.component.ts
+++ b/web-ui/src/app/components/tree-visualizer/external-tree-visualizer.component.ts
@@ -1,22 +1,24 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router'
+import { TreeVisualizerDisplay } from './tree-visualizer.component';
 
 @Component({
-  selector: 'grt-external-tree-visualizer',
-  templateUrl: './external-tree-visualizer.component.html',
-  styleUrls: ['./external-tree-visualizer.component.scss']
+    selector: 'grt-external-tree-visualizer',
+    templateUrl: './external-tree-visualizer.component.html',
+    styleUrls: ['./external-tree-visualizer.component.scss']
 })
 export class ExternalTreeVisualizerComponent implements OnInit {
-  public xml: string;
-  public sentence: string;
+    public xml: string;
+    public sentence: string;
+    public treeDisplay: TreeVisualizerDisplay = 'fullscreen';
 
-  constructor(private activatedRoute: ActivatedRoute) { }
+    constructor(private activatedRoute: ActivatedRoute) { }
 
-  ngOnInit() {
-    this.activatedRoute.queryParams.subscribe(params => {
-      this.xml = params['xml'];
-      this.sentence = params['sent'];
-    });
-  }
+    ngOnInit() {
+        this.activatedRoute.queryParams.subscribe(params => {
+            this.xml = params['xml'];
+            this.sentence = params['sent'];
+        });
+    }
 
 }

--- a/web-ui/src/app/components/tree-visualizer/tree-visualizer.component.ts
+++ b/web-ui/src/app/components/tree-visualizer/tree-visualizer.component.ts
@@ -20,7 +20,7 @@ import { DownloadService, ParseService } from '../../services/_index';
 import './tree-visualizer';
 
 type TypedChanges = { [name in keyof TreeVisualizerComponent]: SimpleChange };
-type TreeVisualizerDisplay = 'fullscreen' | 'inline' | 'both';
+export type TreeVisualizerDisplay = 'fullscreen' | 'inline' | 'both';
 interface Metadata {
     name: string;
     /**

--- a/web-ui/src/app/components/xpath/editor/xpath-editor.component.html
+++ b/web-ui/src/app/components/xpath/editor/xpath-editor.component.html
@@ -1,1 +1,1 @@
-<lx-editor width="100%" [value]="value" (onChange)="onChange.emit($event)" autofocus="true"></lx-editor>
+<lx-editor width="100%" [value]="value" (onChange)="onChange.emit($event)" [autofocus]="true"></lx-editor>

--- a/web-ui/src/app/models/filter.ts
+++ b/web-ui/src/app/models/filter.ts
@@ -1,0 +1,25 @@
+interface FilterBase {
+    field: string;
+    options: string[];
+}
+
+export interface DateFilter extends FilterBase {
+    filterType: 'range';
+    dataType: 'date';
+    minValue: Date;
+    maxValue: Date;
+}
+
+export interface TextFilter extends FilterBase {
+    filterType: 'checkbox' | 'dropdown';
+    dataType: 'text';
+}
+
+export interface IntFilter extends FilterBase {
+    filterType: 'slider';
+    dataType: 'int';
+    minValue: number;
+    maxValue: number;
+}
+
+export type Filter = DateFilter | TextFilter | IntFilter;

--- a/web-ui/src/app/models/matrix.spec.ts
+++ b/web-ui/src/app/models/matrix.spec.ts
@@ -1,0 +1,91 @@
+import { DefaultTokenAttributes, Matrix, TokenAttributes } from './matrix';
+
+describe('Matrix', () => {
+    let matrix: Matrix;
+    beforeEach(() => {
+        matrix = Matrix.default(5);
+    });
+
+    it('should set', () => {
+        expect(matrix.attributes[0].lemma).toEqual(undefined);
+        let changed = matrix.set(0, 'lemma', 'include');
+        expect(matrix.attributes[0].lemma).toEqual('include');
+        expect(changed).toEqual(true);
+
+        changed = matrix.set(0, 'lemma', 'include');
+        expect(changed).toEqual(false);
+    });
+
+    it('should handle na', () => {
+        let changed = matrix.set(0, 'na', true);
+        expect(changed).toEqual(true);
+        expect(matrix.attributes[0]).toEqual(<TokenAttributes>{
+            rel: undefined,
+            word: undefined,
+            lemma: undefined,
+            pos: undefined,
+            cs: false,
+            postag: undefined,
+            na: true
+        });
+
+        changed = matrix.set(0, 'na', false);
+        expect(changed).toEqual(true);
+        expect(matrix.attributes[0]).toEqual(DefaultTokenAttributes);
+    });
+
+    it('should handle case sensitive', () => {
+        matrix.set(0, 'cs', true);
+        expect(matrix.attributes[0].word).toEqual('include');
+
+        // case-sensitive should be switched off if word is switched off
+        matrix.set(0, 'word', undefined);
+        expect(matrix.attributes[0].cs).toEqual(false);
+        expect(matrix.attributes[0].word).toEqual(undefined);
+
+        // word should be switched on if case-sensitive is switched on
+        matrix.set(0, 'cs', true);
+        expect(matrix.attributes[0].cs).toEqual(true);
+        expect(matrix.attributes[0].word).toEqual('include');
+    });
+
+    it('setting word, should turn off only na', () => {
+        let changed = matrix.set(0, 'na', true);
+        expect(changed).toEqual(true);
+        expect(matrix.attributes[0]).toEqual(<TokenAttributes>{
+            rel: undefined,
+            word: undefined,
+            lemma: undefined,
+            pos: undefined,
+            cs: false,
+            postag: undefined,
+            na: true
+        });
+
+        changed = matrix.set(0, 'word', 'include');
+        expect(changed).toEqual(true);
+        expect(matrix.attributes[0]).toEqual({
+            rel: undefined,
+            word: 'include',
+            lemma: undefined,
+            pos: undefined,
+            cs: false,
+            postag: undefined,
+            na: false
+        });
+    });
+
+    it('setting everything else off, should turn on na', () => {
+        expect(matrix.attributes[0].na).toEqual(false);
+
+        matrix.set(0, 'rel', undefined);
+        matrix.set(0, 'lemma', undefined);
+        matrix.set(0, 'pos', undefined);
+        matrix.set(0, 'cs', false);
+        matrix.set(0, 'postag', undefined);
+        matrix.set(0, 'rel', undefined);
+        matrix.set(0, 'word', undefined);
+
+        expect(matrix.attributes[0].na).toEqual(true);
+    });
+});

--- a/web-ui/src/app/models/matrix.spec.ts
+++ b/web-ui/src/app/models/matrix.spec.ts
@@ -47,6 +47,12 @@ describe('Matrix', () => {
         matrix.set(0, 'cs', true);
         expect(matrix.attributes[0].cs).toEqual(true);
         expect(matrix.attributes[0].word).toEqual('include');
+
+        // case-sensitive is also allowed for exclude
+        matrix.set(0, 'cs', false);
+        matrix.set(0, 'word', 'exclude');
+        matrix.set(0, 'cs', true);
+        expect(matrix.attributes[0].word).toEqual('exclude');
     });
 
     it('setting word, should turn off only na', () => {

--- a/web-ui/src/app/models/matrix.ts
+++ b/web-ui/src/app/models/matrix.ts
@@ -131,11 +131,17 @@ export class Matrix {
         const option = optionsLookup[key];
         if (option.dependent_on) {
             let dependency = optionsLookup[option.dependent_on];
-            this.set(
-                tokenIndex,
-                option.dependent_on,
-                dependency.type === 'default' ? 'include' : true,
-                sourceKey);
+
+            switch (this.attributes[tokenIndex][option.dependent_on]) {
+                case undefined:
+                case false:
+                    this.set(
+                        tokenIndex,
+                        option.dependent_on,
+                        dependency.type === 'default' ? 'include' : true,
+                        sourceKey);
+                    break;
+            }
         }
     }
 
@@ -375,5 +381,16 @@ export class Matrix {
         this.set(tokenIndex, key, updated);
 
         return updated;
+    }
+
+    /**
+     * Rotate all the values in this row. If they differ, the first one
+     * is used to set the rest.
+     */
+    rotateRow<T extends MatrixOptionKey>(key: T): void {
+        const value = this.rotate(0, key);
+        for (let tokenIndex = 1; tokenIndex < this.attributes.length; tokenIndex++) {
+            this.set(tokenIndex, key, value);
+        }
     }
 }

--- a/web-ui/src/app/models/matrix.ts
+++ b/web-ui/src/app/models/matrix.ts
@@ -1,0 +1,379 @@
+type FilterKey = 'rel' | 'word' | 'lemma' | 'pos' | 'postag';
+type BoolKey = 'cs' | 'na';
+
+export type MatrixOptionKey = FilterKey | BoolKey;
+export type FilterValue = 'include' | 'exclude' | undefined;
+
+type MatrixOptionInfo = {
+    key: MatrixOptionKey
+    label: string;
+    description: string;
+    dependent_on?: MatrixOptionKey;
+    advanced: boolean;
+    exclusive: boolean;
+}
+
+type MatrixFilterOption = {
+    type: 'default';
+    default: FilterValue
+} & MatrixOptionInfo;
+
+
+type MatrixBoolOption = {
+    type: 'bool'
+    default: boolean;
+} & MatrixOptionInfo;
+
+export type MatrixOption = {
+} & (MatrixFilterOption | MatrixBoolOption);
+
+type Keyless<T> = {
+    [Property in keyof T as Exclude<Property, "key">]: T[Property]
+};
+
+export const optionsLookup: Record<FilterKey, Keyless<MatrixFilterOption>> &
+    Record<BoolKey, Keyless<MatrixBoolOption>> = {
+    'rel':
+    {
+        label: 'Relation',
+        description: 'The exact word form (also known as token).',
+        advanced: false,
+        exclusive: false,
+        type: 'default',
+        default: 'include'
+    },
+    'word': {
+        label: 'Word',
+        description: 'The exact word form (also known as token).',
+        advanced: false,
+        exclusive: false,
+        type: 'default',
+        default: 'include'
+    },
+    'cs': {
+        label: 'Word (case-sensitive)',
+        description: 'The word form must match exactly, including the casing.',
+        dependent_on: 'word',
+        advanced: true,
+        exclusive: false,
+        type: 'bool',
+        default: false
+    },
+    'lemma': {
+        label: 'Lemma',
+        description: `Word form that generalizes over inflected forms.
+        For example: gaan is the lemma of ga, gaat, gaan, ging, gingen, and gegaan.`,
+        advanced: false,
+        exclusive: false,
+        type: 'default',
+        default: undefined
+    },
+    'pos': {
+        label: 'Word class',
+        description: `Short Dutch part-of-speech tag.
+        The different tags are:
+        n (noun), ww (verb), adj (adjective), lid (article), vnw (pronoun),
+        vg (conjunction), bw (adverb), tw (numeral), vz (preposition),
+        tsw (interjection), spec (special token), and let (punctuation).`,
+        advanced: false,
+        exclusive: false,
+        type: 'default',
+        default: 'include'
+    },
+    'postag': {
+        label: 'Detailed word class',
+        description: 'Long part-of-speech tag. For example: N(soort,mv,basis), WW(pv,tgw,ev), VNW(pers,pron,nomin,vol,2v,ev).',
+        advanced: true,
+        exclusive: false,
+        type: 'default',
+        default: undefined
+    },
+    'na': {
+        label: 'Optional',
+        description: `The word will be ignored in the search instruction.
+        It may be included in the results, but it is not required that it is present.`,
+        advanced: false,
+        exclusive: true,
+        type: 'bool',
+        default: false
+    }
+};
+
+export type TokenAttributes = Record<FilterKey, FilterValue> & Record<BoolKey, boolean>;
+export type TokenDependents = Record<MatrixOptionKey, boolean>;
+
+export const matrixOptions: MatrixOption[] = Object.entries(optionsLookup).map(([key, value]) => ({
+    key: <MatrixOptionKey>key,
+    ...value
+}));
+export const DefaultTokenAttributes: TokenAttributes = Object.assign(
+    {},
+    ...matrixOptions.map(option => ({ [option.key]: option.default })));
+
+export class Matrix {
+    static default(length: number) {
+        return new Matrix(
+            Array(length).fill(undefined).map(() => ({
+                ...DefaultTokenAttributes
+            })));
+    }
+
+    private constructor(public attributes: TokenAttributes[]) {
+    }
+
+    /**
+     * If the passed option has dependencies, make sure those are set
+     */
+    private setDependents(
+        tokenIndex: number,
+        key: MatrixOptionKey,
+        sourceKey: MatrixOptionKey): void {
+        const option = optionsLookup[key];
+        if (option.dependent_on) {
+            let dependency = optionsLookup[option.dependent_on];
+            this.set(
+                tokenIndex,
+                option.dependent_on,
+                dependency.type === 'default' ? 'include' : true,
+                sourceKey);
+        }
+    }
+
+    /**
+     * If this option is exclusive: unset everything else
+     */
+    private setExclusive(
+        tokenIndex: number,
+        key: MatrixOptionKey,
+        sourceKey: MatrixOptionKey): void {
+        if (!optionsLookup[key].exclusive) {
+            // this option is not exclusive
+            return;
+        }
+
+        // unset all the other options
+        for (let option of matrixOptions) {
+            if (option.key !== key) {
+                this.set(
+                    tokenIndex,
+                    option.key,
+                    option.type === 'default' ? undefined : false,
+                    sourceKey);
+            }
+        }
+    }
+
+    /**
+     * If the set option is exclusive:
+     * reset everything else to default values
+     */
+    private unsetExclusive(
+        tokenIndex: number,
+        key: MatrixOptionKey,
+        sourceKey: MatrixOptionKey): void {
+        if (!optionsLookup[key].exclusive || key !== sourceKey) {
+            // this option is not exclusive
+            return;
+        }
+
+        // reset all the other options to their defaults
+        for (let option of matrixOptions) {
+            if (option.key !== key) {
+                this.set(
+                    tokenIndex,
+                    option.key,
+                    DefaultTokenAttributes[option.key],
+                    sourceKey);
+            }
+        }
+
+        return;
+    }
+
+    /**
+     * If another option is exclusive, unset that
+     */
+    private unsetOtherExclusive(
+        tokenIndex: number,
+        key: MatrixOptionKey,
+        sourceKey: MatrixOptionKey): void {
+        for (let option of matrixOptions) {
+            if (option.key !== key && option.exclusive) {
+                this.set(
+                    tokenIndex,
+                    option.key,
+                    option.type === 'default' ? undefined : false,
+                    sourceKey);
+            }
+        }
+    }
+    /**
+     * If nothing else is set, then 'not applicable' should be set
+     */
+    private autoNa(
+        tokenIndex: number,
+        key: MatrixOptionKey,
+        sourceKey: MatrixOptionKey): void {
+        if (key !== sourceKey || key === 'na') {
+            // check once after all other changes are applied
+            return;
+        }
+
+        for (let option of matrixOptions) {
+            if (option.key !== key && option.key !== 'na') {
+                switch (this.attributes[tokenIndex][option.key]) {
+                    case 'include':
+                    case 'exclude':
+                    case true:
+                        // another option has been set!
+                        return;
+                }
+            }
+        }
+
+        this.set(
+            tokenIndex,
+            'na',
+            true,
+            sourceKey);
+    }
+
+    /**
+     * If this option is unset and another option dependent, unset that
+     */
+    private unsetDependent(
+        tokenIndex: number,
+        key: MatrixOptionKey,
+        sourceKey: MatrixOptionKey): void {
+        for (let option of matrixOptions) {
+            if (option.dependent_on === key) {
+                this.set(
+                    tokenIndex,
+                    option.key,
+                    option.type === 'default' ? undefined : false,
+                    sourceKey);
+            }
+        }
+
+        return;
+    }
+
+    info(): {
+        advanced: boolean,
+        dependents: TokenDependents[]
+    } {
+        let advanced = false;
+        let dependents = this.attributes.map((attributes) => {
+            const result = {
+                rel: false,
+                word: false,
+                lemma: false,
+                pos: false,
+                cs: false,
+                postag: false,
+                na: false
+            };
+            let exclusive: MatrixOptionKey;
+            for (let option of matrixOptions) {
+                if (option.dependent_on) {
+                    switch (attributes[option.dependent_on]) {
+                        case undefined:
+                        case false:
+                            result[option.key] = true;
+                            break;
+                    }
+                }
+
+                if (option.exclusive) {
+                    switch (attributes[option.key]) {
+                        case 'include':
+                        case 'exclude':
+                        case true:
+                            exclusive = option.key;
+                            break;
+                    }
+                }
+
+                advanced ||= option.advanced && attributes[option.key] !== DefaultTokenAttributes[option.key];
+            }
+
+            if (exclusive) {
+                for (let option of matrixOptions) {
+                    if (option.key !== exclusive) {
+                        result[option.key] = true;
+                    }
+                }
+            }
+
+            return result;
+        });
+
+        return {
+            advanced,
+            dependents
+        };
+    }
+
+    setMultiple(attributes: TokenAttributes[]): boolean {
+        let changed = false;
+        for (let tokenIndex = 0; tokenIndex < attributes.length; tokenIndex++) {
+            for (let [key, value] of Object.entries(attributes[tokenIndex])) {
+                changed = this.set(tokenIndex, key as MatrixOptionKey, value) || changed;
+            }
+        }
+        return changed;
+    }
+
+    set<T extends MatrixOptionKey>(tokenIndex: number, key: T, value: TokenAttributes[T], sourceKey: T = undefined): boolean {
+        if (sourceKey === undefined) {
+            sourceKey = key;
+        }
+
+        if (this.attributes[tokenIndex][key] === value) {
+            return false;
+        } else {
+            this.attributes[tokenIndex][key] = value;
+            if (value === true || value === 'include' || value === 'exclude') {
+                this.setDependents(tokenIndex, key, sourceKey);
+                this.setExclusive(tokenIndex, key, sourceKey);
+                this.unsetOtherExclusive(tokenIndex, key, sourceKey);
+            } else {
+                this.unsetDependent(tokenIndex, key, sourceKey);
+                this.unsetExclusive(tokenIndex, key, sourceKey);
+                this.autoNa(tokenIndex, key, sourceKey);
+            }
+
+            return true;
+        }
+    }
+
+    rotate<T extends MatrixOptionKey>(tokenIndex: number, key: T): TokenAttributes[T] {
+        const mod = (optionValues: any[]): TokenAttributes[T] => {
+            const current = this.attributes[tokenIndex][key];
+
+            const index = optionValues.indexOf(current) + 1;
+            return optionValues[index % optionValues.length];
+        }
+
+        let updated: TokenAttributes[T];
+
+        switch (key) {
+            case 'cs':
+            case 'na':
+                updated = mod([true, false]);
+                break;
+
+            case 'lemma':
+            case 'pos':
+            case 'postag':
+            case 'rel':
+            case 'word':
+                updated = mod(['include', 'exclude', undefined]);
+                break;
+        }
+
+        this.set(tokenIndex, key, updated);
+
+        return updated;
+    }
+}

--- a/web-ui/src/app/modules/filters/date/date.component.ts
+++ b/web-ui/src/app/modules/filters/date/date.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { FilterDirective } from '../filter/filter.directive';
-import { Filter } from '../filters.component';
+import { DateFilter } from '../../../models/filter';
 import { FilterValue } from '../../../services/_index';
 
 @Component({
@@ -8,11 +8,11 @@ import { FilterValue } from '../../../services/_index';
     templateUrl: './date.component.html',
     styleUrls: ['./date.component.scss']
 })
-export class DateComponent extends FilterDirective {
+export class DateComponent extends FilterDirective<DateFilter> {
     minValue: Date;
     maxValue: Date;
 
-    onFilterSet(filter: Filter) {
+    onFilterSet(filter: DateFilter) {
         this.minValue = this.minValue || filter.minValue as Date;
         this.maxValue = this.maxValue || filter.maxValue as Date;
     }

--- a/web-ui/src/app/modules/filters/dropdown/dropdown.component.ts
+++ b/web-ui/src/app/modules/filters/dropdown/dropdown.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { FilterDirective } from '../filter/filter.directive';
-import { Filter } from '../filters.component';
+import { TextFilter } from '../../../models/filter';
 import { FilterValue } from '../../../services/_index';
 
 @Component({
@@ -8,10 +8,10 @@ import { FilterValue } from '../../../services/_index';
     templateUrl: './dropdown.component.html',
     styleUrls: ['./dropdown.component.scss']
 })
-export class DropdownComponent extends FilterDirective {
+export class DropdownComponent extends FilterDirective<TextFilter> {
     public selected: string[];
 
-    onFilterSet(filter: Filter) {
+    onFilterSet(filter: TextFilter) {
         if (!this.selected) {
             this.selected = [];
         }

--- a/web-ui/src/app/modules/filters/filter/filter.directive.ts
+++ b/web-ui/src/app/modules/filters/filter/filter.directive.ts
@@ -1,32 +1,28 @@
 import { EventEmitter, Input, Output, Directive } from '@angular/core';
-import { Filter } from '../filters.component';
-import { FilterByField } from '../../../services/_index';
+import { Filter } from '../../../models/filter';
+import { FilterValue } from '../../../services/_index';
 
-export type FilterChangeEvent = FilterByField & {
+export type FilterChangeEvent = FilterValue & {
     selected: boolean
 };
 
 @Directive()
-export abstract class FilterDirective {
-    private filterDefinition: Filter;
+export abstract class FilterDirective<T extends Filter> {
+    filter: T;
 
-    @Input('filterValue') set filterValue(value: FilterByField) {
+    @Input('filterValue') set filterValue(value: FilterValue) {
         this.onFilterValueSet(value);
     }
 
-    @Input('filter') set filter(value: Filter) {
-        this.filterDefinition = value;
+    @Input('filter') set filterDefinition(value: Filter) {
+        this.filter = <T>value;
         if (value !== undefined) {
-            this.onFilterSet(value);
+            this.onFilterSet(<T>value);
         }
     }
 
     @Output()
     filterChange = new EventEmitter<FilterChangeEvent>();
-
-    get filter() {
-        return this.filterDefinition;
-    }
 
     constructor() {
     }
@@ -39,6 +35,6 @@ export abstract class FilterDirective {
         throw Error('Not implemented');
     }
 
-    abstract onFilterSet(filter: Filter): void;
-    abstract onFilterValueSet(filterValue: FilterByField): void;
+    abstract onFilterSet(filter: T): void;
+    abstract onFilterValueSet(filterValue: FilterValue): void;
 }

--- a/web-ui/src/app/modules/filters/filters.component.html
+++ b/web-ui/src/app/modules/filters/filters.component.html
@@ -8,7 +8,7 @@
         </p>
         <ng-container [ngSwitch]="filter.filterType">
             <grt-text *ngSwitchCase="'checkbox'" [filter]="filter" [filterValue]="filterValues[filter.field]" (filterChange)="filterChanged($event)"></grt-text>
-            <grt-int *ngSwitchCase="'slider'" [filter]="filter" [filterValue]="filterValues[filter.field]" (filterChange)="filterChanged($event)"></grt-int>
+            <grt-int *ngSwitchCase="'slider'" [ filter]="filter" [filterValue]="filterValues[filter.field]" (filterChange)="filterChanged($event)"></grt-int>
             <grt-date *ngSwitchCase="'range'" [filter]="filter" [filterValue]="filterValues[filter.field]" (filterChange)="filterChanged($event)"></grt-date>
             <grt-dropdown *ngSwitchCase="'dropdown'" [filter]="filter" [filterValue]="filterValues[filter.field]" (filterChange)="filterChanged($event)"></grt-dropdown>
         </ng-container>

--- a/web-ui/src/app/modules/filters/filters.component.ts
+++ b/web-ui/src/app/modules/filters/filters.component.ts
@@ -1,15 +1,7 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { FilterByField, FilterValues } from '../../services/_index';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Filter } from '../../models/filter';
+import { FilterValue, FilterValues } from '../../services/_index';
 import { FilterChangeEvent } from './filter/filter.directive';
-
-export interface Filter {
-    field: string;
-    dataType: string;
-    filterType: 'checkbox' | 'slider' | 'range' | 'dropdown';
-    options: string[];
-    minValue?: Date | number;
-    maxValue?: Date | number;
-}
 
 @Component({
     selector: 'grt-filters',
@@ -34,13 +26,13 @@ export class FiltersComponent {
         }
     }
 
-    private addToSelectedFilters(filterValue: FilterByField) {
+    private addToSelectedFilters(filterValue: FilterValue) {
         this.filterChange.emit(Object.assign({}, this.filterValues, {
             [filterValue.field]: filterValue
         }));
     }
 
-    private removeFromSelectedFilters(filterValue: FilterByField) {
+    private removeFromSelectedFilters(filterValue: FilterValue) {
         const { [filterValue.field]: _, ...remaining } = this.filterValues;
         this.filterChange.emit(remaining);
     }

--- a/web-ui/src/app/modules/filters/int/int.component.spec.ts
+++ b/web-ui/src/app/modules/filters/int/int.component.spec.ts
@@ -17,7 +17,7 @@ describe('IntComponent', () => {
         component.filter = {
             dataType: 'int',
             field: 'range',
-            filterType: 'range',
+            filterType: 'slider',
             minValue: -42,
             maxValue: 42,
             options: []

--- a/web-ui/src/app/modules/filters/int/int.component.ts
+++ b/web-ui/src/app/modules/filters/int/int.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { FilterDirective } from '../filter/filter.directive';
-import { Filter } from '../filters.component';
+import { IntFilter } from '../../../models/filter';
 import { FilterValue } from '../../../services/results.service';
 
 @Component({
@@ -8,12 +8,12 @@ import { FilterValue } from '../../../services/results.service';
     templateUrl: './int.component.html',
     styleUrls: ['./int.component.scss']
 })
-export class IntComponent extends FilterDirective {
+export class IntComponent extends FilterDirective<IntFilter> {
     public value: number;
 
     rangeValues: number[] = [0, 0];
 
-    onFilterSet(filter: Filter) {
+    onFilterSet(filter: IntFilter) {
         this.rangeValues = [this.rangeValues[0] || filter.minValue as number || 0,
         this.rangeValues[1] || filter.maxValue as number || 0];
     }

--- a/web-ui/src/app/modules/filters/text/text.component.ts
+++ b/web-ui/src/app/modules/filters/text/text.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { FilterDirective } from '../filter/filter.directive';
-import { Filter } from '../filters.component';
+import { TextFilter } from '../../../models/filter';
 import { FilterValue } from '../../../services/_index';
 
 @Component({
@@ -8,12 +8,12 @@ import { FilterValue } from '../../../services/_index';
     templateUrl: './text.component.html',
     styleUrls: ['./text.component.scss']
 })
-export class TextComponent extends FilterDirective {
+export class TextComponent extends FilterDirective<TextFilter> {
     public options: string[] = [];
 
     public values: { [value: string]: boolean } = {};
 
-    onFilterSet(filter: Filter) {
+    onFilterSet(filter: TextFilter) {
         this.options = filter.options.sort((a, b) => a.localeCompare(
             b,
             undefined,

--- a/web-ui/src/app/pages/multi-step-page/steps.ts
+++ b/web-ui/src/app/pages/multi-step-page/steps.ts
@@ -1,6 +1,7 @@
 import { ExtractinatorService, ReconstructorService, PathVariable } from 'lassy-xpath';
 
-import { AlpinoService, TokenAttributes } from '../../services/alpino.service';
+import { TokenAttributes } from '../../models/matrix';
+import { AlpinoService } from '../../services/alpino.service';
 import { TreebankService } from '../../services/treebank.service';
 import { FilterValues, SearchVariable, NotificationService } from '../../services/_index';
 import { TreebankSelection } from '../../treebank';

--- a/web-ui/src/app/services/alpino.service.ts
+++ b/web-ui/src/app/services/alpino.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from "@angular/common/http";
 import { ParserService } from 'lassy-xpath';
 import { ConfigurationService } from "./configuration.service";
 import { DefaultTokenAttributes } from '../pages/multi-step-page/steps';
+import { TokenAttributes, FilterValue } from '../models/matrix';
 
 @Injectable()
 export class AlpinoService {
@@ -95,6 +96,16 @@ export class AlpinoService {
                 ...DefaultTokenAttributes
             };
 
+            const notApplicable = parts.indexOf('na') >= 0;
+            if (notApplicable) {
+                for (let key of Object.keys(attributes)) {
+                    attributes[key]
+                }
+                parts = Object.keys(DefaultTokenAttributes)
+                    .filter(key => key != 'cs')
+                    .map(key => `~${key}`);
+            }
+
             for (let part of parts) {
                 const key = part.replace(/^[-~]/, '');
                 switch (key) {
@@ -108,7 +119,7 @@ export class AlpinoService {
                     case 'lemma':
                     case 'pos':
                     case 'postag':
-                        let value: DefaultValue;
+                        let value: FilterValue;
                         switch (part[0]) {
                             case '-':
                                 value = 'exclude';
@@ -152,17 +163,3 @@ export class AlpinoService {
         return encodeURIComponent(sentence.replace(/\//g, '_SLASH_'));
     }
 }
-
-export type DefaultValue = 'include' | 'exclude' | undefined;
-
-export interface TokenAttributes {
-    rel?: DefaultValue,
-    word?: DefaultValue,
-    lemma?: DefaultValue,
-    pos?: DefaultValue,
-    cs?: boolean,
-    postag?: DefaultValue,
-    na?: boolean
-}
-
-export type AttributeType = keyof TokenAttributes;


### PR DESCRIPTION
This should hopefully make the matrix option logic a better more understandable. It will automatically change the other options when required. For example when setting a token to "optional" everything else is disabled. When a property is then enabled (e.g. 'word' is included), optional is set "off" but everything else remains the same. If 'case-sensitive' is set, 'word' will automatically be set to "included", if 'word' is then changed to "optional" 'case-sensitive' is then set to "off".

![image](https://user-images.githubusercontent.com/24268578/181565201-0f9415eb-c556-4d31-b5dd-cb33050aca18.png)