### PR TITLE
Refactor results filters

### DIFF
--- a/web-ui/src/app/components/step/results/results-table.component.ts
+++ b/web-ui/src/app/components/step/results/results-table.component.ts
@@ -31,6 +31,9 @@ export class ResultsTableComponent implements OnInit, OnDestroy {
     public loading = true;
 
     @Input()
+    public loadingDownload = true;
+
+    @Input()
     public filteredResults = [];
 
     @Input()

--- a/web-ui/src/app/components/step/results/results-table.component.ts
+++ b/web-ui/src/app/components/step/results/results-table.component.ts
@@ -1,6 +1,24 @@
-import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, OnDestroy, NgZone } from '@angular/core';
+import { Subscription, Observable, combineLatest } from 'rxjs';
+import {
+    debounceTime,
+    distinctUntilChanged,
+    mergeMap,
+    map,
+    switchMap
+} from 'rxjs/operators';
 import { animations } from '../../../animations';
-import { HitWithOrigin, FilterValues, FilterByXPath } from '../../../services/_index';
+import { TreebankMetadata, TreebankSelection } from '../../../treebank';
+import {
+    HitWithOrigin, FilterValues, FilterByXPath,
+    StateService,
+    MetadataValueCounts,
+    ResultsService,
+} from '../../../services/_index';
+import { GlobalState } from '../../../pages/multi-step-page/steps';
+import { Filter } from '../../../models/filter';
+
+const DebounceTime = 200;
 
 @Component({
     animations,
@@ -8,7 +26,7 @@ import { HitWithOrigin, FilterValues, FilterByXPath } from '../../../services/_i
     templateUrl: './results-table.component.html',
     styleUrls: ['./results-table.component.scss'],
 })
-export class ResultsTableComponent implements OnInit {
+export class ResultsTableComponent implements OnInit, OnDestroy {
     @Input()
     public loading = true;
 
@@ -16,19 +34,10 @@ export class ResultsTableComponent implements OnInit {
     public filteredResults = [];
 
     @Input()
-    public filters = [];
-
-    @Input('filterValues')
-    public filterValues: FilterValues;
-
-    @Input()
     /**
      * Filters on node properties created in the analysis component
      */
     public filterXPaths: FilterByXPath[] = [];
-
-    @Input()
-    public activeFilterCount: number;
 
     @Input()
     public retrieveContext: boolean;
@@ -57,12 +66,15 @@ export class ResultsTableComponent implements OnInit {
     @Output()
     public toggleContext = new EventEmitter<void>();
 
+    public activeFilterCount: number;
+    public filters: Filter[] = [];
+    public filterValues: FilterValues;
     /**
      * Toggle filters column
      */
     public hideFiltersColumn = false;
     public hiddenCount = 0;
-    public loadingDownload = false;
+    private subscriptions: Subscription[];
 
     public columns = [
         { field: 'number', header: '#', width: '5%' },
@@ -71,9 +83,43 @@ export class ResultsTableComponent implements OnInit {
         { field: 'highlightedSentence', header: 'Sentence', width: 'fill' },
     ];
 
-    ngOnInit() {
-        this.filteredResults = [];
+    constructor(
+        ngZone: NgZone,
+        private resultsService: ResultsService,
+        stateService: StateService<GlobalState>) {
+        const state$ = stateService.state$;
+
+        const {
+            xpath$,
+            filterValues$,
+            selectedTreebanks$
+        } = this.statePipe(state$, 'xpath', 'filterValues', 'selectedTreebanks');
+
+        // the metadata properties for the selected treebanks
+        const treebankMetadata$ = this.streamTreebankMetadata(selectedTreebanks$);
+        // the values for the properties
+        const metadataValueCounts$ = this.streamMetadataValueCounts(xpath$, selectedTreebanks$, filterValues$);
+
+        // subscribed streams
+        const filters$ = this.streamFilters(treebankMetadata$, metadataValueCounts$);
+
+        this.subscriptions = [
+            filterValues$.subscribe(filterValues => ngZone.run(() => {
+                this.filterValues = filterValues;
+            })),
+            filters$.subscribe(filters => ngZone.run(() => {
+                this.filters = filters;
+            }))
+        ];
     }
+
+    ngOnInit(): void {
+    }
+
+    ngOnDestroy() {
+        this.subscriptions.forEach(s => s.unsubscribe());
+    }
+
 
     public filterChange(filterValues: FilterValues) {
         this.changeFilterValues.next(filterValues);
@@ -81,5 +127,119 @@ export class ResultsTableComponent implements OnInit {
 
     public print() {
         (window as any).print();
+    }
+
+    private statePipe<T extends keyof GlobalState>(
+        state$: Observable<GlobalState>,
+        ...keys: T[]) {
+        type ObservableStateProperties = { [Key in T as `${Key}$`]: Observable<GlobalState[Key]> };
+        const result: Partial<ObservableStateProperties> = {};
+
+        for (const key of keys) {
+            result[`${key}$`] = state$.pipe(
+                map(state => state[key]),
+                debounceTime(DebounceTime),
+                distinctUntilChanged()) as any;
+        }
+
+        return result as ObservableStateProperties;
+
+    }
+
+    /** Extracts metadata fields from the selected treebanks */
+    private streamTreebankMetadata(selectedTreebanks$: Observable<TreebankSelection>): Observable<TreebankMetadata[]> {
+        return selectedTreebanks$.pipe(
+            switchMap(selection => Promise.all(selection.corpora.map(corpus => corpus.corpus.treebank))),
+            switchMap(treebanks => Promise.all(treebanks.map(t => t.details.metadata()))),
+            mergeMap(metadata => metadata));
+    }
+
+    private streamMetadataValueCounts(
+        xpath$: Observable<string>,
+        selectedTreebanks$: Observable<TreebankSelection>,
+        filterValues$: Observable<FilterValues>): Observable<MetadataValueCounts> {
+        return combineLatest([xpath$, selectedTreebanks$, filterValues$]).pipe(
+            switchMap(([xpath, selectedTreebanks, filterValues]) => this.getMetadataValueCounts(xpath, selectedTreebanks, filterValues)));
+    }
+
+    /** Retrieves metadata counts based on selected banks and filters */
+    private async getMetadataValueCounts(
+        xpath: string,
+        selectedTreebanks: TreebankSelection,
+        filterValues: FilterValues
+    ): Promise<MetadataValueCounts> {
+        const counts = await Promise.all(selectedTreebanks.corpora.map(({ provider, corpus }) =>
+            this.resultsService.metadataCounts(
+                xpath,
+                provider,
+                corpus.name,
+                corpus.components,
+                Object.values(filterValues)
+            ).catch((): MetadataValueCounts => {
+                return {};
+            }))
+        );
+
+        // deep merge all results into a single object
+        return this.mergeMetadataValueCounts(counts);
+    }
+
+    private mergeMetadataValueCounts(c: MetadataValueCounts[]): MetadataValueCounts {
+        return c.reduce<MetadataValueCounts>((counts, cur) => {
+            Object.keys(cur)
+                .forEach(fieldName => {
+                    const field = counts[fieldName] = counts[fieldName] || {};
+                    Object.entries(cur[fieldName])
+                        .forEach(([metadataValue, valueCount]) => {
+                            field[metadataValue] = (field[metadataValue] || 0) + valueCount;
+                        });
+                });
+
+            return counts;
+        }, {});
+    }
+
+    /** Transforms metadata fields along with their values into filter definitions */
+    private streamFilters(
+        metadataFields$: Observable<TreebankMetadata[]>,
+        metadataValues$: Observable<MetadataValueCounts>,
+    ): Observable<Filter[]> {
+        return combineLatest([
+            metadataFields$,
+            metadataValues$
+        ])
+            .pipe(
+                debounceTime(100), // lots of values bouncing around during initialization
+                map(([fields, counts]) => this.getFilters(fields, counts))
+            );
+    }
+
+    private getFilters(fields: TreebankMetadata[], counts: MetadataValueCounts): Filter[] {
+        return fields
+            .filter(field => field.show)
+            .map<Filter>(item => {
+                const options: string[] = [];
+                if (item.field in counts) {
+                    for (const key of Object.keys(counts[item.field])) {
+                        // TODO: show the frequency (the data it right here now!)
+                        options.push(key);
+                    }
+                }
+
+                // use a dropdown instead of checkboxes when there
+                // are too many options
+                if (item.facet === 'checkbox' && options.length > 8) {
+                    item.facet = 'dropdown';
+                }
+
+                return <Filter>{
+                    field: item.field,
+                    dataType: item.type,
+                    filterType: item.facet,
+                    minValue: item.minValue,
+                    maxValue: item.maxValue,
+                    options
+                };
+            });
     }
 }

--- a/web-ui/src/app/components/step/results/results.component.html
+++ b/web-ui/src/app/components/step/results/results.component.html
@@ -15,10 +15,7 @@
 <grt-results-table
     [loading]="loading"
     [filteredResults]="filteredResults"
-    [filters]="filters"
-    [filterValues]="filterValues"
     [filterXPaths]="filterXPaths"
-    [activeFilterCount]="activeFilterCount"
     [retrieveContext]="retrieveContext"
     (changeFilterValues)="filterChange($event)"
     (deleteFilter)="deleteFilter($event)"

--- a/web-ui/src/app/components/step/results/results.component.html
+++ b/web-ui/src/app/components/step/results/results.component.html
@@ -14,6 +14,7 @@
 </div>
 <grt-results-table
     [loading]="loading"
+    [loadingDownload]="loadingDownload"
     [filteredResults]="filteredResults"
     [filterXPaths]="filterXPaths"
     [retrieveContext]="retrieveContext"

--- a/web-ui/src/app/components/step/results/results.component.ts
+++ b/web-ui/src/app/components/step/results/results.component.ts
@@ -361,6 +361,7 @@ export class ResultsComponent extends StepDirective<GlobalState> implements OnIn
         ).pipe(
             filter((values) => values.every(value => value != null)),
             map(([state, filterValues]) => ({
+                retrieveContext: state.retrieveContext,
                 selectedTreebanks: state.selectedTreebanks,
                 xpath: state.xpath,
                 filterValues
@@ -371,18 +372,19 @@ export class ResultsComponent extends StepDirective<GlobalState> implements OnIn
                 // already give feedback a change is pending,
                 // so the user doesn't think the interface is stuck
                 this.loading = true;
-                return prev.filterValues === curr.filterValues &&
+                return prev.retrieveContext === curr.retrieveContext &&
+                    prev.filterValues === curr.filterValues &&
                     prev.xpath === curr.xpath &&
                     prev.selectedTreebanks.equals(curr.selectedTreebanks);
             }),
             debounceTime(DebounceTime),
-            switchMap(({ selectedTreebanks, xpath, filterValues }) => {
+            switchMap(({ selectedTreebanks, xpath, filterValues, retrieveContext }) => {
                 // create a request for each treebank
                 const resultStreams = this.resultsStreamService.stream(
                     xpath,
                     selectedTreebanks,
                     filterValues,
-                    this.retrieveContext);
+                    retrieveContext);
 
                 // join all results, and wrap the entire sequence in a start and end message so
                 // we know what's happening and can update spinners etc.

--- a/web-ui/src/app/components/step/results/results.component.ts
+++ b/web-ui/src/app/components/step/results/results.component.ts
@@ -1,13 +1,12 @@
 import { Component, Input, OnDestroy, Output, EventEmitter, OnInit } from '@angular/core';
 import { SafeHtml } from '@angular/platform-browser';
 
-import { combineLatest as observableCombineLatest, BehaviorSubject, Subscription, Observable, merge, combineLatest } from 'rxjs';
+import { combineLatest, BehaviorSubject, Subscription, Observable, merge } from 'rxjs';
 import {
     debounceTime,
     distinctUntilChanged,
     endWith,
     filter,
-    mergeMap,
     map,
     shareReplay,
     startWith,
@@ -24,15 +23,13 @@ import {
     FilterValue,
     FilterValues,
     HitWithOrigin,
-    MetadataValueCounts,
     ResultsService,
     ResultsStreamService,
     StateService,
-    TreebankSelectionService,
     ParseService,
     NotificationService
 } from '../../../services/_index';
-import { TreebankMetadata, TreebankSelection } from '../../../treebank';
+import { TreebankSelection } from '../../../treebank';
 import { StepDirective } from '../step.directive';
 import { NotificationKind } from './notification-kind';
 import { GlobalState, StepType, getSearchVariables } from '../../../pages/multi-step-page/steps';
@@ -62,7 +59,6 @@ type HidableHit = HitWithOrigin & { hidden: boolean };
 })
 export class ResultsComponent extends StepDirective<GlobalState> implements OnInit, OnDestroy {
     private treebankSelection: TreebankSelection;
-    private xpathSubject = new BehaviorSubject<string>(undefined);
     private filterValuesSubject = new BehaviorSubject<FilterValues>({});
 
     public hidden: HideSettings = {};
@@ -70,9 +66,7 @@ export class ResultsComponent extends StepDirective<GlobalState> implements OnIn
     public filteredResults: HidableHit[] = [];
     public stepType = StepType.Results;
 
-    @Input('xpath')
-    public set xpath(value: string) { this.xpathSubject.next(value); }
-    public get xpath(): string { return this.xpathSubject.value; }
+    public xpath: string;
     public validXPath = true;
     public customXPath: string;
     @Output()
@@ -131,7 +125,6 @@ export class ResultsComponent extends StepDirective<GlobalState> implements OnIn
         private notificationService: NotificationService,
         private resultsService: ResultsService,
         private resultsStreamService: ResultsStreamService,
-        private treebankSelectionService: TreebankSelectionService,
         private parseService: ParseService,
         stateService: StateService<GlobalState>
     ) {
@@ -143,7 +136,6 @@ export class ResultsComponent extends StepDirective<GlobalState> implements OnIn
         super.ngOnInit();
         // intermediate streams
         const state$ = this.state$.pipe(
-            debounceTime(1000),
             shareReplay(1), // this stream is used as input in multiple others, no need to re-run it for every subscription.
         );
         const filterValues$ = this.filterValuesSubject.pipe( // the user-selected values
@@ -151,21 +143,15 @@ export class ResultsComponent extends StepDirective<GlobalState> implements OnIn
             map(v => Object.values(v)),
             shareReplay(1),
         );
-        // the metadata properties for the selected treebanks
-        const metadataProperties$ = this.createMetadataPropertiesStream();
-        // the values for the properties
-        const metadataCounts$ = this.createMetadataCountsStream(state$, this.xpathSubject, filterValues$);
 
-        // subscribed streams
-        const metadataFilters$ = this.createMetadataFiltersStream(metadataProperties$, metadataCounts$);
-        const results$ = this.createResultsStream(state$, this.xpathSubject, filterValues$);
+        const results$ = this.createResultsStream(state$, filterValues$);
 
         this.subscriptions = [
             state$.subscribe(state => {
                 this.treebankSelection = state.selectedTreebanks;
                 this.variableProperties = state.variableProperties;
+                this.xpath = state.xpath;
             }),
-            metadataFilters$.subscribe(filters => this.filters = filters),
 
             results$.subscribe(r => {
                 if (typeof r === 'string') {
@@ -358,106 +344,6 @@ export class ResultsComponent extends StepDirective<GlobalState> implements OnIn
 
     // ----
 
-    /** Extracts metadata fields from the selected treebanks */
-    private createMetadataPropertiesStream(): Observable<TreebankMetadata[]> {
-        return this.treebankSelectionService.state$.pipe(
-            switchMap(selection => Promise.all(selection.corpora.map(corpus => corpus.corpus.treebank))),
-            switchMap(treebanks => Promise.all(treebanks.map(t => t.details.metadata()))),
-            mergeMap(metadata => metadata));
-    }
-
-    /** Retrieves metadata counts based on selected banks and filters */
-    private createMetadataCountsStream(
-        state$: Observable<GlobalState>,
-        xpath$: Observable<string>,
-        filterValues$: Observable<FilterValue[]>
-    ): Observable<MetadataValueCounts> {
-        return observableCombineLatest(
-            state$,
-            xpath$,
-            filterValues$
-        )
-            .pipe(
-                debounceTime(DebounceTime),
-                distinctUntilChanged(),
-                switchMap(([state, xpath, filterValues]) =>
-                    // TODO: change to stream-based approach, so we can cancel http requests?
-                    // TODO: error handling, just ignore that metadata?
-                    // would need to check if requests are actually cancelled in the angular http service
-
-                    // get counts for all selected
-                    Promise.all(state.selectedTreebanks.corpora.map(({ provider, corpus }) =>
-                        this.resultsService.metadataCounts(
-                            xpath,
-                            provider,
-                            corpus.name,
-                            corpus.components,
-                            filterValues
-                        ).catch((): MetadataValueCounts => {
-                            return {};
-                        }))
-                    )
-                        // deep merge all results into a single object
-                        .then((c: MetadataValueCounts[]) => {
-                            return c.reduce<MetadataValueCounts>((counts, cur) => {
-                                Object.keys(cur)
-                                    .forEach(fieldName => {
-                                        const field = counts[fieldName] = counts[fieldName] || {};
-                                        Object.entries(cur[fieldName])
-                                            .forEach(([metadataValue, valueCount]) => {
-                                                field[metadataValue] = (field[metadataValue] || 0) + valueCount;
-                                            });
-                                    });
-
-                                return counts;
-                            }, {});
-                        })
-                ),
-            );
-    }
-
-    /** Transforms metadata fields along with their values into filter definitions */
-    private createMetadataFiltersStream(
-        metadataFields$: Observable<TreebankMetadata[]>,
-        metadataValues$: Observable<MetadataValueCounts>,
-    ): Observable<Filter[]> {
-        return combineLatest(
-            metadataFields$,
-            metadataValues$
-        )
-            .pipe(
-                debounceTime(100), // lots of values bouncing around during initialization
-                map(([fields, counts]) => {
-                    return fields
-                        .filter(field => field.show)
-                        .map<Filter>(item => {
-                            const options: string[] = [];
-                            if (item.field in counts) {
-                                for (const key of Object.keys(counts[item.field])) {
-                                    // TODO: show the frequency (the data it right here now!)
-                                    options.push(key);
-                                }
-                            }
-
-                            // use a dropdown instead of checkboxes when there
-                            // are too many options
-                            if (item.facet === 'checkbox' && options.length > 8) {
-                                item.facet = 'dropdown';
-                            }
-
-                            return <Filter>{
-                                field: item.field,
-                                dataType: item.type,
-                                filterType: item.facet,
-                                minValue: item.minValue,
-                                maxValue: item.maxValue,
-                                options
-                            };
-                        });
-                })
-            );
-    }
-
     /**
      * Gets up-to-date results for all selected treebanks
      *
@@ -468,26 +354,28 @@ export class ResultsComponent extends StepDirective<GlobalState> implements OnIn
      */
     private createResultsStream(
         state$: Observable<GlobalState>,
-        xpath$: Observable<string>,
         filterValue$: Observable<FilterValue[]>
     ) {
-        return observableCombineLatest(
-            state$,
-            xpath$,
-            filterValue$
+        return combineLatest(
+            [state$, filterValue$]
         ).pipe(
             filter((values) => values.every(value => value != null)),
-            debounceTime(DebounceTime),
-            map(([state, xpath, filterValues]) => ({
+            map(([state, filterValues]) => ({
                 selectedTreebanks: state.selectedTreebanks,
-                xpath,
+                xpath: state.xpath,
                 filterValues
             })),
             distinctUntilChanged((prev, curr) => {
+                // results are going to be reloaded, but we need to
+                // wait for the debouncing first.
+                // already give feedback a change is pending,
+                // so the user doesn't think the interface is stuck
+                this.loading = true;
                 return prev.filterValues === curr.filterValues &&
                     prev.xpath === curr.xpath &&
                     prev.selectedTreebanks.equals(curr.selectedTreebanks);
             }),
+            debounceTime(DebounceTime),
             switchMap(({ selectedTreebanks, xpath, filterValues }) => {
                 // create a request for each treebank
                 const resultStreams = this.resultsStreamService.stream(

--- a/web-ui/src/app/modules/filters/filters.component.html
+++ b/web-ui/src/app/modules/filters/filters.component.html
@@ -8,7 +8,7 @@
         </p>
         <ng-container [ngSwitch]="filter.filterType">
             <grt-text *ngSwitchCase="'checkbox'" [filter]="filter" [filterValue]="filterValues[filter.field]" (filterChange)="filterChanged($event)"></grt-text>
-            <grt-int *ngSwitchCase="'slider'" [ filter]="filter" [filterValue]="filterValues[filter.field]" (filterChange)="filterChanged($event)"></grt-int>
+            <grt-int *ngSwitchCase="'slider'" [filter]="filter" [filterValue]="filterValues[filter.field]" (filterChange)="filterChanged($event)"></grt-int>
             <grt-date *ngSwitchCase="'range'" [filter]="filter" [filterValue]="filterValues[filter.field]" (filterChange)="filterChanged($event)"></grt-date>
             <grt-dropdown *ngSwitchCase="'dropdown'" [filter]="filter" [filterValue]="filterValues[filter.field]" (filterChange)="filterChanged($event)"></grt-dropdown>
         </ng-container>

--- a/web-ui/src/app/pages/example-based-search/example-based-search.component.html
+++ b/web-ui/src/app/pages/example-based-search/example-based-search.component.html
@@ -37,7 +37,6 @@
         [filterValues]="globalState.filterValues"
         [inputSentence]="globalState.inputSentence"
         [retrieveContext]="globalState.retrieveContext"
-        [xpath]="globalState.xpath"
 
         (changeValid)="setValid($event)"
         (changeXpath)="updateXPath($event)"

--- a/web-ui/src/app/pages/example-based-search/example-based-search.component.ts
+++ b/web-ui/src/app/pages/example-based-search/example-based-search.component.ts
@@ -140,10 +140,10 @@ export class ExampleBasedSearchComponent extends MultiStepPageDirective<GlobalSt
             newState.attributes = matrixSettings.attributes;
         }
 
-        let state: GlobalStateExampleBased = await this.stateService.setState(newState);
+        let state = this.stateService.setState(newState);
         state = await this.matrixStep.updateMatrix(state);
         state.loading = false;
-        state = await this.stateService.setState(state);
+        this.stateService.setState(state);
     }
 
     updateRetrieveContext(retrieveContext: boolean) {

--- a/web-ui/src/app/pages/multi-step-page/multi-step-page.directive.ts
+++ b/web-ui/src/app/pages/multi-step-page/multi-step-page.directive.ts
@@ -13,7 +13,7 @@ import { TreebankSelection } from '../../treebank';
 @Directive()
 export abstract class MultiStepPageDirective<T extends GlobalState> implements OnDestroy, OnInit {
     public crumbs: Crumb[];
-    public globalState: T;
+    public globalState: Readonly<T>;
     public warning: string | false;
     /**
      * Whether the next step is currently being resolved
@@ -132,8 +132,8 @@ export abstract class MultiStepPageDirective<T extends GlobalState> implements O
         this.stateService.next();
     }
 
-    setValid(valid: boolean) {
-        this.globalState.valid = valid;
+    setValid(valid: boolean): void {
+        this.stateService.setState({ valid }, false);
     }
 
     updateUrl(state: T, writeState = true) {
@@ -151,12 +151,12 @@ export abstract class MultiStepPageDirective<T extends GlobalState> implements O
     }
 
     updateFilterValues(filterValues: FilterValues) {
-        this.globalState.filterValues = filterValues;
+        this.stateService.setState({ filterValues }, false);
     }
 
     filterResults(values: { xpath: string, filterValues: FilterValues }, resultsStep: number) {
         // TODO: xpath
-        this.globalState.filterValues = values.filterValues;
+        this.stateService.setState({ filterValues: values.filterValues }, false);
         this.goToStep(resultsStep);
     }
 

--- a/web-ui/src/app/pages/xpath-search/xpath-search.component.html
+++ b/web-ui/src/app/pages/xpath-search/xpath-search.component.html
@@ -24,7 +24,6 @@
         [filterValues]="globalState.filterValues"
         [inputSentence]="globalState.inputSentence"
         [retrieveContext]="globalState.retrieveContext"
-        [xpath]="globalState.xpath"
 
         (changeValid)="setValid($event)"
         (changeXpath)="updateXPath($event, 'history')"

--- a/web-ui/src/app/services/state.service.ts
+++ b/web-ui/src/app/services/state.service.ts
@@ -163,7 +163,7 @@ class SharedInstance<T extends GlobalState> {
         }
     }
 
-    setState(values: { [K in keyof GlobalState]?: GlobalState[K] }, emit: EmitType = false) {
+    setState(values: { [K in keyof GlobalState]?: GlobalState[K] }, emit: EmitType = false): T & { emit: EmitType } {
         const nextState = {
             ...this.state$.value,
             ...values,
@@ -248,7 +248,7 @@ export class StateService<T extends GlobalState> {
         return this.instance.jump(stepNumber, emit);
     }
 
-    setState(values: { [K in keyof T]?: T[K] }, emit: EmitType = 'in-place') {
+    setState(values: Partial<T> | Partial<GlobalState>, emit: EmitType = 'in-place'): T {
         return this.instance.setState(values, emit);
     }
 

--- a/web-ui/src/app/services/treebank-selection.service.ts
+++ b/web-ui/src/app/services/treebank-selection.service.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@angular/core';
 import { StateService } from './state.service';
 import { TreebankService } from './treebank.service';
 import { GlobalState, StepType } from '../pages/multi-step-page/steps';
-import { Treebank, TreebankDetails, CorpusSelection } from '../treebank';
+import { Treebank, TreebankDetails, CorpusSelection, TreebankSelection } from '../treebank';
+import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 type DetailLookup<T extends keyof TreebankDetails> = Pick<TreebankDetails, T>;
@@ -11,7 +12,7 @@ type DetailLookup<T extends keyof TreebankDetails> = Pick<TreebankDetails, T>;
     providedIn: 'root'
 })
 export class TreebankSelectionService {
-    get state$() {
+    get state$(): Observable<TreebankSelection> {
         return this.stateService.state$.pipe(map(state => state.selectedTreebanks));
     }
 

--- a/web-ui/tsconfig.json
+++ b/web-ui/tsconfig.json
@@ -22,7 +22,7 @@
         "lib": [
             "es2018",
             "dom",
-            "esnext.array"
+            "es2019.array"
         ],
         "paths": {
             "@angular/": [


### PR DESCRIPTION
Retrieving context and filters work again. More data is read from the `StateService`  directly instead of passing them through multiple components. I think the `StateService` could be used more extensively as this contains the information determining for what should be done anyway. But that would make the rewrite even more extensive.